### PR TITLE
fix: Forward auth responses to the user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58b567e8b518469c73c8d7e4798d5abcd7db76a1b33121fffd36ac6fa62da05"
 dependencies = [
  "async-trait",
- "axum",
  "bytes",
  "chrono",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ axum = { version = "0.7.5", default-features = false, features = ["multipart","m
 time = { version = "0.3.36", features = ["wasm-bindgen"] }
 console_error_panic_hook = "0.1.7"
 wasm-bindgen = "0.2.92"
-worker = { version = "0.3.0", features = ["http", "axum"] }
+worker = { version = "0.3.0", features = ["http"] }
 tracing-web = "0.1.3"
 futures = "0.3.30"
 

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -10,25 +10,6 @@ use tracing_subscriber::EnvFilter;
 use tracing_web::MakeWebConsoleWriter;
 use worker::{console_log, event, Body, Cf, Context, Env};
 
-/// Wrap an async route handler into a closure that can be used in the router.
-///
-/// Allows request handlers to return Result<Response, pyoci::Error> instead of worker::Result<worker::Response>
-// macro_rules! wrap {
-//     ($e:expr) => {
-//         |req: Request<Body>, ctx: RouteContext<()>| async { wrap($e(req, ctx).await) }
-//     };
-// }
-//
-// fn wrap(res: Result<Response>) -> worker::Result<Response> {
-//     match res {
-//         Ok(response) => Ok(response),
-//         Err(e) => match e.downcast_ref::<OciError>() {
-//             Some(err) => Response::error(err.to_string(), err.status().into()),
-//             None => Response::error(e.to_string(), 400),
-//         },
-//     }
-// }
-
 /// Called once when the worker is started
 #[event(start)]
 fn start() {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,3 +1,5 @@
+use anyhow::Result;
+use http::StatusCode;
 use std::sync::{Arc, Mutex};
 use url::Url;
 
@@ -36,10 +38,7 @@ impl HttpTransport {
     /// When authentication is required, this method will automatically authenticate
     /// using the provided Basic auth string and caches the Bearer token for future requests within
     /// this session.
-    pub async fn send(
-        &self,
-        request: reqwest::RequestBuilder,
-    ) -> Result<reqwest::Response, reqwest::Error> {
+    pub async fn send(&self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
         let org_request = request.try_clone();
         let bearer_token = {
             // Local scope the bearer lock
@@ -47,12 +46,12 @@ impl HttpTransport {
             token.clone()
         };
         let request = match bearer_token {
-            Some(token) => request.header("Authorization", sens_header(&token)),
+            Some(token) => request.header("Authorization", sens_header(&token)?),
             None => request,
         };
-        let response = self._send(request).await.expect("valid response");
-        if response.status() != 401 {
-            // TODO: support returning 403 when the authentication is not sufficient
+        let response = self._send(request).await?;
+        if response.status() != StatusCode::UNAUTHORIZED {
+            // No authentication needed or some error happened
             return Ok(response);
         }
         let Some(org_request) = org_request else {
@@ -62,7 +61,7 @@ impl HttpTransport {
         // Authenticate
         let www_auth: WwwAuth = match response.headers().get("WWW-Authenticate") {
             None => return Ok(response),
-            Some(value) => match WwwAuth::parse(value.to_str().expect("valid header")) {
+            Some(value) => match WwwAuth::parse(value.to_str()?) {
                 Ok(value) => value,
                 Err(_) => return Ok(response),
             },
@@ -72,23 +71,23 @@ impl HttpTransport {
             return Ok(response);
         };
 
-        let mut auth_url = Url::parse(&www_auth.realm).expect("valid url");
+        let mut auth_url = Url::parse(&www_auth.realm)?;
         auth_url
             .query_pairs_mut()
             .append_pair("grant_type", "password")
-            // TODO: if client_id is needed, add it here
-            // Although GitHub does not seem to need a valid client_id
+            // if client_id is needed, add it here,
+            // although GitHub does not seem to need a valid client_id
             // .append_pair("client_id", username)
             .append_pair("service", &www_auth.service);
         let auth_request = self.get(auth_url).header("Authorization", basic_token);
-        let auth_response = self._send(auth_request).await.expect("valid response");
+        let auth_response = self._send(auth_request).await?;
 
-        if auth_response.status() != 200 {
-            // Authentication failed, return the original response
-            return Ok(response);
+        if auth_response.status() != StatusCode::OK {
+            // Authentication failed
+            return Ok(auth_response);
         }
 
-        let auth_response: AuthResponse = auth_response.json().await.expect("valid json");
+        let auth_response: AuthResponse = auth_response.json().await?;
         let bearer_token = {
             // Local scope the bearer lock and update the token
             let mut token = self.bearer.lock().unwrap();
@@ -96,20 +95,17 @@ impl HttpTransport {
             *token = Some(new_token.clone());
             new_token
         };
-        self._send(org_request.header("Authorization", sens_header(&bearer_token)))
+        self._send(org_request.header("Authorization", sens_header(&bearer_token)?))
             .await
     }
 
     /// Send a request
-    async fn _send(
-        &self,
-        request: reqwest::RequestBuilder,
-    ) -> Result<reqwest::Response, reqwest::Error> {
-        let request = request.build().expect("valid request");
+    async fn _send(&self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
+        let request = request.build()?;
         tracing::debug!("Request: {:#?}", request);
         let method = request.method().as_str().to_string();
         let url = request.url().to_owned().to_string();
-        let response = self.client.execute(request).await.expect("valid response");
+        let response = self.client.execute(request).await?;
         let status: u16 = response.status().into();
         tracing::info!(method, status, url, "type" = "subrequest");
         tracing::debug!("Response Headers: {:#?}", response.headers());
@@ -135,8 +131,192 @@ impl HttpTransport {
 }
 
 /// Create a new HeaderValue with sensitive data
-fn sens_header(value: &str) -> reqwest::header::HeaderValue {
-    let mut header = reqwest::header::HeaderValue::from_str(value).expect("valid header");
+fn sens_header(value: &str) -> Result<reqwest::header::HeaderValue> {
+    let mut header = reqwest::header::HeaderValue::from_str(value)?;
     header.set_sensitive(true);
-    header
+    Ok(header)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test happy-flow, no auth needed
+    #[tokio::test]
+    async fn http_transport_send() {
+        let mut server = mockito::Server::new_async().await;
+        let mocks = vec![
+            server
+                .mock("GET", "/foobar")
+                .with_status(200)
+                .with_body("Hello, world!")
+                .create_async()
+                .await,
+        ];
+
+        let transport = HttpTransport::new(None);
+        let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
+        let response = transport.send(request).await.unwrap();
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.text().await.unwrap(), "Hello, world!");
+    }
+
+    /// Test happy-flow, with authentication
+    #[tokio::test]
+    async fn http_transport_send_auth() {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+        let mocks = vec![
+            // Response to unauthenticated request
+            server
+                .mock("GET", "/foobar")
+                .with_status(401)
+                .with_header(
+                    "WWW-Authenticate",
+                    &format!("Bearer realm=\"{url}/token\",service=\"pyoci.fakeservice\""),
+                )
+                .create_async()
+                .await,
+            // Token exchange
+            server
+                .mock(
+                    "GET",
+                    "/token?grant_type=password&service=pyoci.fakeservice",
+                )
+                .match_header("Authorization", "Basic mybasicauth")
+                .with_status(200)
+                .with_body(r#"{"token":"mytoken"}"#)
+                .create_async()
+                .await,
+            // Re-submitted request, with bearer auth
+            server
+                .mock("GET", "/foobar")
+                .match_header("Authorization", "Bearer mytoken")
+                .with_status(200)
+                .with_body("Hello, world!")
+                .create_async()
+                .await,
+        ];
+
+        let transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
+        let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
+        let response = transport.send(request).await.unwrap();
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.text().await.unwrap(), "Hello, world!");
+    }
+
+    /// Test missing authentication
+    #[tokio::test]
+    async fn http_transport_send_missing_auth() {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+        let mocks = vec![
+            server
+                .mock("GET", "/foobar")
+                .with_status(401)
+                .with_header(
+                    "WWW-Authenticate",
+                    &format!("Bearer realm=\"{url}/token\",service=\"pyoci.fakeservice\""),
+                )
+                .with_body("Unauthorized")
+                .create_async()
+                .await,
+        ];
+
+        let transport = HttpTransport::new(None);
+        let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
+        let response = transport.send(request).await.unwrap();
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.text().await.unwrap(), "Unauthorized");
+    }
+    /// Test authentication failure
+    #[tokio::test]
+    async fn http_transport_send_auth_failure() {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+        let mocks = vec![
+            server
+                .mock("GET", "/foobar")
+                .with_status(401)
+                .with_header(
+                    "WWW-Authenticate",
+                    &format!("Bearer realm=\"{url}/token\",service=\"pyoci.fakeservice\""),
+                )
+                .with_body("Unauthorized")
+                .create_async()
+                .await,
+            server
+                .mock(
+                    "GET",
+                    "/token?grant_type=password&service=pyoci.fakeservice",
+                )
+                .with_status(418)
+                .create_async()
+                .await,
+        ];
+
+        let transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
+        let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
+        let response = transport.send(request).await.unwrap();
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+        assert_eq!(response.status(), StatusCode::IM_A_TEAPOT);
+        assert_eq!(response.text().await.unwrap(), "");
+    }
+    /// Test unauthorized
+    #[tokio::test]
+    async fn http_transport_send_unauthorized() {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+        let mocks = vec![
+            server
+                .mock("GET", "/foobar")
+                .with_status(401)
+                .with_header(
+                    "WWW-Authenticate",
+                    &format!("Bearer realm=\"{url}/token\",service=\"pyoci.fakeservice\""),
+                )
+                .with_body("Unauthorized")
+                .create_async()
+                .await,
+            // Token exchange
+            server
+                .mock(
+                    "GET",
+                    "/token?grant_type=password&service=pyoci.fakeservice",
+                )
+                .match_header("Authorization", "Basic mybasicauth")
+                .with_status(200)
+                .with_body(r#"{"token":"mytoken"}"#)
+                .create_async()
+                .await,
+            // Re-submitted request, with bearer auth
+            server
+                .mock("GET", "/foobar")
+                .match_header("Authorization", "Bearer mytoken")
+                .with_status(403)
+                .with_body("Forbidden")
+                .create_async()
+                .await,
+        ];
+
+        let transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
+        let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
+        let response = transport.send(request).await.unwrap();
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.text().await.unwrap(), "Forbidden");
+    }
 }


### PR DESCRIPTION
When Authentication or Authorization is not sufficient, return the
OCI registry response code and body.

closes: #6
closes: #9
