### PR TITLE
refactor: Implement log and authentication as `tower::Layer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,7 @@ dependencies = [
  "console_error_panic_hook",
  "exitcode",
  "futures",
+ "futures-util",
  "http 1.1.0",
  "mockito",
  "oci-spec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,7 @@ dependencies = [
  "mockito",
  "oci-spec",
  "opentelemetry-proto",
+ "pin-project",
  "prost",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ features = [
 ]
 
 [dev-dependencies]
+futures-util = "0.3.30"
 mockito = "1.4.0"
 test-case = "3.3.1"
 tokio = { version = "1.39.1", features = ["macros"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ prost = "0.12.6"
 async-channel = "2.3.1"
 tower = "0.4.13"
 async-trait = "0.1.81"
+pin-project = "1.1.5"
 
 [dependencies.web-sys]
 version = "0.3.63"

--- a/src/app.rs
+++ b/src/app.rs
@@ -99,7 +99,7 @@ async fn list_package(
 
     let package: package::Info = path_params.0.try_into()?;
 
-    let mut client = PyOci::new(package.registry.clone(), auth);
+    let mut client = PyOci::new(package.registry.clone(), auth)?;
     // Fetch at most 45 packages
     // https://developers.cloudflare.com/workers/platform/limits/#account-plan-limits
     let files = client.list_package_files(&package, 45).await?;
@@ -126,7 +126,7 @@ async fn download_package(
     };
     let package: package::Info = path_params.0.try_into()?;
 
-    let mut client = PyOci::new(package.registry.clone(), auth);
+    let mut client = PyOci::new(package.registry.clone(), auth)?;
     let data = client
         .download_package_file(&package)
         .await?
@@ -164,7 +164,7 @@ async fn publish_package(
         None => None,
     };
     let package: package::Info = (registry, namespace, None, form_data.filename).try_into()?;
-    let mut client = PyOci::new(package.registry.clone(), auth);
+    let mut client = PyOci::new(package.registry.clone(), auth)?;
 
     client
         .publish_package_file(&package, form_data.content)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ mod pyoci;
 mod templates;
 // HTTP Transport
 mod transport;
+// Services
+mod service;
 // Re-export the PyOci client
 pub use pyoci::PyOci;
 

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -214,7 +214,7 @@ where
 
     fn on_close(&self, id: tracing_core::span::Id, ctx: Context<'_, S>) {
         let span = ctx.span(&id).expect("span not found");
-        if !span.parent().is_none() {
+        if span.parent().is_some() {
             // This is a sub-span, we'll flush all messages when the root span is closed
             return;
         }

--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -209,11 +209,11 @@ pub struct PyOci {
 
 impl PyOci {
     /// Create a new Client
-    pub fn new(registry: Url, auth: Option<String>) -> Self {
-        PyOci {
+    pub fn new(registry: Url, auth: Option<String>) -> Result<Self> {
+        Ok(PyOci {
             registry,
-            transport: HttpTransport::new(auth),
-        }
+            transport: HttpTransport::new(auth)?,
+        })
     }
 
     /// List all files for the given package
@@ -638,7 +638,7 @@ mod tests {
     fn test_build_url() -> Result<()> {
         let client = PyOci {
             registry: Url::parse("https://example.com").expect("valid url"),
-            transport: HttpTransport::new(None),
+            transport: HttpTransport::new(None).unwrap(),
         };
         let url = build_url!(&client, "/foo/{}/", "latest");
         assert_eq!(url.as_str(), "https://example.com/foo/latest/");
@@ -649,7 +649,7 @@ mod tests {
     fn test_build_url_absolute() -> Result<()> {
         let client = PyOci {
             registry: Url::parse("https://example.com").expect("valid url"),
-            transport: HttpTransport::new(None),
+            transport: HttpTransport::new(None).unwrap(),
         };
         let url = build_url!(&client, "{}/foo?bar=baz&qaz=sha:123", "http://pyoci.nl");
         assert_eq!(url.as_str(), "http://pyoci.nl/foo?bar=baz&qaz=sha:123");
@@ -660,7 +660,7 @@ mod tests {
     fn test_build_url_double_period() {
         let client = PyOci {
             registry: Url::parse("https://example.com").expect("valid url"),
-            transport: HttpTransport::new(None),
+            transport: HttpTransport::new(None).unwrap(),
         };
         let x = || -> Result<Url> { Ok(build_url!(&client, "/foo/{}/", "..")) }();
         assert!(x.is_err());
@@ -712,7 +712,7 @@ mod tests {
 
         let mut client = PyOci {
             registry: Url::parse(&url).expect("valid url"),
-            transport: HttpTransport::new(None),
+            transport: HttpTransport::new(None).unwrap(),
         };
         let blob = Blob::new("hello".into(), "application/octet-stream");
         assert!(client.push_blob("mockserver/foobar", blob).await.is_ok());
@@ -767,7 +767,7 @@ mod tests {
 
         let mut client = PyOci {
             registry: Url::parse(&url).expect("valid url"),
-            transport: HttpTransport::new(None),
+            transport: HttpTransport::new(None).unwrap(),
         };
         let blob = Blob::new("hello".into(), "application/octet-stream");
         assert!(client.push_blob("mockserver/foobar", blob).await.is_ok());

--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -156,7 +156,7 @@ pub struct AuthResponse {
 /// WWW-Authenticate header
 /// ref: <https://datatracker.ietf.org/doc/html/rfc6750#section-3>
 pub struct WwwAuth {
-    pub realm: String,
+    pub realm: Url,
     pub service: String,
     // scope: String,
 }
@@ -175,15 +175,16 @@ impl WwwAuth {
             .unwrap()
             .captures(value)
         {
-            Some(value) => value.name("realm").unwrap().as_str().to_string(),
-            None => bail!("`realm` key missing from WWW-Authenticate header"),
+            Some(value) => value.name("realm").unwrap().as_str(),
+            None => bail!("`realm` key missing"),
         };
+        let realm = Url::parse(realm).context("Failed to parse realm URL")?;
         let service = match Regex::new(r#"service="(?P<service>[^"\s]*)"#)
             .expect("valid regex")
             .captures(value)
         {
             Some(value) => value.name("service").unwrap().as_str().to_string(),
-            None => bail!("`service` key missing from WWW-Authenticate header"),
+            None => bail!("`service` key missing"),
         };
         // let scope = match Regex::new(r#"scope="(?P<scope>[^"]*)"#)
         //     .expect("valid regex")

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -1,0 +1,261 @@
+use futures::ready;
+use http::StatusCode;
+use pin_project::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+use url::Url;
+
+use crate::pyoci::{AuthResponse, WwwAuth};
+
+#[derive(Debug, Default, Clone)]
+pub struct AuthLayer {
+    // The Basic token to trade for a Bearer token
+    basic: Option<http::HeaderValue>,
+    // The Bearer token to use for authentication
+    // Will be updated after successful authentication
+    bearer: Arc<RwLock<Option<http::HeaderValue>>>,
+}
+
+impl AuthLayer {
+    pub fn new(basic_token: Option<String>) -> Self {
+        let basic_token = basic_token.map(|token| {
+            let mut token =
+                http::HeaderValue::try_from(token).expect("Failed to create basic token");
+            token.set_sensitive(true);
+            token
+        });
+
+        Self {
+            basic: basic_token,
+            bearer: Arc::new(RwLock::new(None)),
+        }
+    }
+}
+
+impl<S> Layer<S> for AuthLayer {
+    type Service = AuthService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        AuthService::new(self.basic.clone(), self.bearer.clone(), service)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthService<S> {
+    basic: Option<http::HeaderValue>,
+    bearer: Arc<RwLock<Option<http::HeaderValue>>>,
+    service: S,
+}
+
+impl<S> AuthService<S> {
+    pub fn new(
+        basic: Option<http::HeaderValue>,
+        bearer: Arc<RwLock<Option<http::HeaderValue>>>,
+        service: S,
+    ) -> Self {
+        Self {
+            bearer,
+            basic,
+            service,
+        }
+    }
+}
+
+impl<S> Service<reqwest::Request> for AuthService<S>
+where
+    S: Service<reqwest::Request, Response = reqwest::Response> + Clone + Send + 'static,
+    <S as Service<reqwest::Request>>::Future: Send,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = AuthFuture<S>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: reqwest::Request) -> Self::Future {
+        if let Some(bearer) = self.bearer.read().expect("Failed to get read lock").clone() {
+            // If we have a bearer token, add it to the request
+            request
+                .headers_mut()
+                .insert(http::header::AUTHORIZATION, bearer);
+        }
+        AuthFuture::new(
+            request.try_clone(),
+            self.clone(),
+            self.service.call(request),
+        )
+    }
+}
+
+#[pin_project(project = AuthStateProj)]
+enum AuthState<F, A> {
+    Called {
+        #[pin]
+        future: F,
+    },
+    Authenticating {
+        #[pin]
+        future: A,
+    },
+}
+
+#[pin_project]
+pub struct AuthFuture<S>
+where
+    S: Service<reqwest::Request, Response = reqwest::Response> + Clone + 'static,
+    <S as Service<reqwest::Request>>::Future: Send,
+{
+    // Clone of the original request to retry after authentication
+    request: Option<reqwest::Request>,
+    // inner service to call after authenticating
+    auth: AuthService<S>,
+    // State of this Future
+    #[pin]
+    state: AuthState<
+        S::Future,
+        Pin<Box<dyn Future<Output = Result<http::HeaderValue, reqwest::Response>> + Send>>,
+    >,
+}
+
+impl<S> AuthFuture<S>
+where
+    S: Service<reqwest::Request, Response = reqwest::Response> + Clone + 'static,
+    <S as Service<reqwest::Request>>::Future: Send,
+{
+    pub fn new(
+        request: Option<reqwest::Request>,
+        inner: AuthService<S>,
+        future: S::Future,
+    ) -> Self {
+        Self {
+            request,
+            auth: inner,
+            state: AuthState::Called { future },
+        }
+    }
+}
+
+impl<S> Future for AuthFuture<S>
+where
+    // Service being called that we might need to authenticate for
+    S: Service<reqwest::Request, Response = reqwest::Response> + Clone + Send + 'static,
+    <S as Service<reqwest::Request>>::Future: Send,
+{
+    type Output = Result<reqwest::Response, S::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        loop {
+            match this.state.as_mut().project() {
+                // Polling original request
+                AuthStateProj::Called { future } => {
+                    let response = ready!(future.poll(cx))?;
+
+                    if response.status() != StatusCode::UNAUTHORIZED {
+                        return Poll::Ready(Ok(response));
+                    }
+                    tracing::debug!("Received 401 response, authenticating");
+                    if this.request.is_none() {
+                        // No clone of the original request, can't retry after authentication
+                        tracing::debug!("No request to retry, skipping authentication");
+                        return Poll::Ready(Ok(response));
+                    }
+                    // Take the basic token, we are only expected to trade it once
+                    let Some(basic_token) = this.auth.basic.take() else {
+                        // No basic token to trade for a bearer token
+                        tracing::debug!("No basic token, skipping authentication");
+                        return Poll::Ready(Ok(response));
+                    };
+
+                    let www_auth = match response.headers().get("WWW-Authenticate") {
+                        None => {
+                            tracing::debug!("No WWW-Authenticate header, skipping authentication");
+                            return Poll::Ready(Ok(response));
+                        }
+                        Some(value) => match WwwAuth::parse(
+                            value
+                                .to_str()
+                                .expect("Header contains non-ASCII characters"),
+                        ) {
+                            Ok(value) => value,
+                            Err(err) => {
+                                tracing::error!("Failed to parse WWW-Authenticate header: {}", err);
+                                return Poll::Ready(Ok(response));
+                            }
+                        },
+                    };
+                    let srv = this.auth.clone();
+                    this.state.set(AuthState::Authenticating {
+                        // No idea how to type this Future, lets just Pin<Box> it
+                        future: Box::pin(async { authenticate(basic_token, www_auth, srv).await }),
+                    });
+                }
+                // Polling authentication request
+                AuthStateProj::Authenticating { future } => match ready!(future.poll(cx)) {
+                    Ok(bearer_token) => {
+                        // Take the original request, this prevent infinitely retrying if the
+                        // server keeps returning 401
+                        let mut request = this.request.take().expect("Failed to take request");
+                        request
+                            .headers_mut()
+                            .insert(http::header::AUTHORIZATION, bearer_token.clone());
+                        this.auth
+                            .bearer
+                            .write()
+                            .expect("Failed to get write lock")
+                            .replace(bearer_token);
+                        // Retry the original request with the new bearer token
+                        this.state.set(AuthState::Called {
+                            future: this.auth.service.call(request),
+                        });
+                    }
+                    Err(response) => return Poll::Ready(Ok(response)),
+                },
+            };
+        }
+    }
+}
+
+// Returns the bearer token if successful.
+// Returns the upstream response of not.
+#[cfg_attr(target_arch = "wasm32", worker::send)]
+async fn authenticate<S>(
+    basic_token: http::HeaderValue,
+    www_auth: WwwAuth,
+    mut service: AuthService<S>,
+    // TODO: Figure out how to do error propagation
+) -> Result<http::HeaderValue, reqwest::Response>
+where
+    S: Service<reqwest::Request, Response = reqwest::Response> + Clone + Send + 'static,
+    <S as Service<reqwest::Request>>::Future: Send,
+{
+    let mut auth_url = Url::parse(&www_auth.realm).expect("Failed to parse realm URL");
+    auth_url
+        .query_pairs_mut()
+        .append_pair("grant_type", "password")
+        .append_pair("service", &www_auth.service);
+    let mut auth_request = reqwest::Request::new(http::Method::GET, auth_url);
+    auth_request
+        .headers_mut()
+        .append("Authorization", basic_token);
+    let Ok(response) = service.call(auth_request).await else {
+        todo!("Handle error");
+    };
+    if response.status() != StatusCode::OK {
+        return Err(response);
+    }
+    let auth = response
+        .json::<AuthResponse>()
+        .await
+        .expect("Failed to parse auth response");
+    let mut token = http::HeaderValue::try_from(format!("Bearer {}", auth.token))
+        .expect("Failed to create bearer token header");
+    token.set_sensitive(true);
+    Ok(token)
+}

--- a/src/service/log.rs
+++ b/src/service/log.rs
@@ -1,0 +1,97 @@
+use futures::ready;
+use pin_project::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use time::OffsetDateTime;
+use tower::{Layer, Service};
+
+#[derive(Debug, Default, Clone)]
+pub struct RequestLogLayer {
+    request_type: &'static str,
+}
+
+impl RequestLogLayer {
+    pub fn new(request_type: &'static str) -> Self {
+        Self { request_type }
+    }
+}
+
+impl<S> Layer<S> for RequestLogLayer {
+    type Service = RequestLog<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        RequestLog::new(self.request_type, service)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RequestLog<S> {
+    request_type: &'static str,
+    inner: S,
+}
+
+impl<S> RequestLog<S> {
+    pub fn new(request_type: &'static str, service: S) -> Self {
+        Self {
+            request_type,
+            inner: service,
+        }
+    }
+}
+
+impl<S> Service<reqwest::Request> for RequestLog<S>
+where
+    S: Service<reqwest::Request, Response = reqwest::Response>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = LogFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: reqwest::Request) -> Self::Future {
+        LogFuture {
+            method: request.method().to_string(),
+            url: request.url().to_string(),
+            inner_fut: self.inner.call(request),
+            request_type: self.request_type,
+            start: OffsetDateTime::now_utc(),
+        }
+    }
+}
+
+#[pin_project]
+pub struct LogFuture<F> {
+    #[pin]
+    inner_fut: F,
+    method: String,
+    url: String,
+    request_type: &'static str,
+    start: OffsetDateTime,
+}
+
+impl<F, Error> Future for LogFuture<F>
+where
+    F: Future<Output = Result<reqwest::Response, Error>>,
+{
+    type Output = Result<reqwest::Response, Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result = ready!(this.inner_fut.poll(cx));
+        if let Ok(response) = &result {
+            let status: u16 = response.status().into();
+            tracing::info!(
+                elapsed_ms = (OffsetDateTime::now_utc() - *this.start).whole_milliseconds(),
+                method = this.method,
+                status,
+                url = this.url,
+                "type" = this.request_type,
+            );
+        }
+        Poll::Ready(result)
+    }
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,0 +1,5 @@
+mod auth;
+mod log;
+
+pub use auth::AuthLayer;
+pub use log::RequestLogLayer;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,22 +1,49 @@
 use anyhow::Result;
-use http::StatusCode;
-use std::sync::{Arc, Mutex};
-use url::Url;
+use std::boxed::Box;
+use std::future::poll_fn;
+use std::future::Future;
+use std::pin::Pin;
+use tower::{Service, ServiceBuilder};
 
-use crate::pyoci::{AuthResponse, WwwAuth};
+use crate::service::AuthLayer;
+use crate::service::RequestLogLayer;
 use crate::USER_AGENT;
 
 /// HTTP Transport
 ///
 /// This struct is responsible for sending HTTP requests to the upstream OCI registry.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct HttpTransport {
     /// HTTP client
     client: reqwest::Client,
-    /// Basic auth string, including the "Basic " prefix
-    basic: Option<String>,
-    /// Bearer token, including the "Bearer " prefix
-    bearer: Arc<Mutex<Option<String>>>,
+    /// Authentication layer
+    auth_layer: AuthLayer,
+}
+
+// Wraps the reqwest client so we can implement Service.
+// reqwest implements Service normally but not for the WASM target.
+// This allows us to use other Service implementations to wrap the reqwest client.
+impl Service<reqwest::Request> for HttpTransport {
+    type Response = reqwest::Response;
+    type Error = reqwest::Error;
+    // we need to box the future as we currently can't express the anonymous `impl Future` type
+    // returned by reqwest::Client::execute
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: reqwest::Request) -> Self::Future {
+        #[cfg(target_arch = "wasm32")]
+        let fut = Box::pin(worker::send::SendFuture::new(self.client.execute(request)));
+        #[cfg(not(target_arch = "wasm32"))]
+        let fut = Box::pin(self.client.execute(request));
+        fut
+    }
 }
 
 impl HttpTransport {
@@ -28,8 +55,7 @@ impl HttpTransport {
         let client = reqwest::Client::builder().user_agent(USER_AGENT);
         Self {
             client: client.build().unwrap(),
-            basic: auth,
-            bearer: Arc::new(Mutex::new(None)),
+            auth_layer: AuthLayer::new(auth),
         }
     }
 
@@ -38,76 +64,17 @@ impl HttpTransport {
     /// When authentication is required, this method will automatically authenticate
     /// using the provided Basic auth string and caches the Bearer token for future requests within
     /// this session.
-    pub async fn send(&self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
-        let org_request = request.try_clone();
-        let bearer_token = {
-            // Local scope the bearer lock
-            let token = self.bearer.lock().unwrap();
-            token.clone()
-        };
-        let request = match bearer_token {
-            Some(token) => request.header("Authorization", sens_header(&token)?),
-            None => request,
-        };
-        let response = self._send(request).await?;
-        if response.status() != StatusCode::UNAUTHORIZED {
-            // No authentication needed or some error happened
-            return Ok(response);
-        }
-        let Some(org_request) = org_request else {
-            return Ok(response);
-        };
-
-        // Authenticate
-        let www_auth: WwwAuth = match response.headers().get("WWW-Authenticate") {
-            None => return Ok(response),
-            Some(value) => match WwwAuth::parse(value.to_str()?) {
-                Ok(value) => value,
-                Err(_) => return Ok(response),
-            },
-        };
-        let Some(basic_token) = &self.basic else {
-            // No credentials provided
-            return Ok(response);
-        };
-
-        let mut auth_url = Url::parse(&www_auth.realm)?;
-        auth_url
-            .query_pairs_mut()
-            .append_pair("grant_type", "password")
-            // if client_id is needed, add it here,
-            // although GitHub does not seem to need a valid client_id
-            // .append_pair("client_id", username)
-            .append_pair("service", &www_auth.service);
-        let auth_request = self.get(auth_url).header("Authorization", basic_token);
-        let auth_response = self._send(auth_request).await?;
-
-        if auth_response.status() != StatusCode::OK {
-            // Authentication failed
-            return Ok(auth_response);
-        }
-
-        let auth_response: AuthResponse = auth_response.json().await?;
-        let bearer_token = {
-            // Local scope the bearer lock and update the token
-            let mut token = self.bearer.lock().unwrap();
-            let new_token = format!("Bearer {}", auth_response.token);
-            *token = Some(new_token.clone());
-            new_token
-        };
-        self._send(org_request.header("Authorization", sens_header(&bearer_token)?))
-            .await
-    }
-
-    /// Send a request
-    async fn _send(&self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
+    pub async fn send(&mut self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
         let request = request.build()?;
         tracing::debug!("Request: {:#?}", request);
-        let method = request.method().as_str().to_string();
-        let url = request.url().to_owned().to_string();
-        let response = self.client.execute(request).await?;
-        let status: u16 = response.status().into();
-        tracing::info!(method, status, url, "type" = "subrequest");
+
+        let mut service = ServiceBuilder::new()
+            .layer(self.auth_layer.clone())
+            .layer(RequestLogLayer::new("subrequest"))
+            .service(self.clone());
+        poll_fn(|ctx| service.poll_ready(ctx)).await?;
+        let response = service.call(request).await?;
+
         tracing::debug!("Response Headers: {:#?}", response.headers());
         Ok(response)
     }
@@ -130,16 +97,11 @@ impl HttpTransport {
     }
 }
 
-/// Create a new HeaderValue with sensitive data
-fn sens_header(value: &str) -> Result<reqwest::header::HeaderValue> {
-    let mut header = reqwest::header::HeaderValue::from_str(value)?;
-    header.set_sensitive(true);
-    Ok(header)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http::StatusCode;
+    use url::Url;
 
     /// Test happy-flow, no auth needed
     #[tokio::test]
@@ -154,7 +116,7 @@ mod tests {
                 .await,
         ];
 
-        let transport = HttpTransport::new(None);
+        let mut transport = HttpTransport::new(None);
         let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -201,7 +163,7 @@ mod tests {
                 .await,
         ];
 
-        let transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
+        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
         let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -229,7 +191,7 @@ mod tests {
                 .await,
         ];
 
-        let transport = HttpTransport::new(None);
+        let mut transport = HttpTransport::new(None);
         let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -264,7 +226,7 @@ mod tests {
                 .await,
         ];
 
-        let transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
+        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
         let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -310,7 +272,7 @@ mod tests {
                 .await,
         ];
 
-        let transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
+        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
         let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -51,12 +51,12 @@ impl HttpTransport {
     ///
     /// auth: Basic auth string
     ///       Will be swapped for a Bearer token if needed
-    pub fn new(auth: Option<String>) -> Self {
+    pub fn new(auth: Option<String>) -> Result<Self> {
         let client = reqwest::Client::builder().user_agent(USER_AGENT);
-        Self {
-            client: client.build().unwrap(),
-            auth_layer: AuthLayer::new(auth),
-        }
+        Ok(Self {
+            client: client.build()?,
+            auth_layer: AuthLayer::new(auth)?,
+        })
     }
 
     /// Send a request
@@ -116,7 +116,7 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(None);
+        let mut transport = HttpTransport::new(None).unwrap();
         let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -163,7 +163,7 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
+        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string())).unwrap();
         let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -191,7 +191,7 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(None);
+        let mut transport = HttpTransport::new(None).unwrap();
         let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -226,7 +226,7 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
+        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string())).unwrap();
         let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -272,7 +272,7 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string()));
+        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string())).unwrap();
         let request = transport.get(Url::parse(&format!("{}/foobar", &server.url())).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {


### PR DESCRIPTION
This PR moves the sub-request logging and authentication to their own
`tower::Layer` middleware.

`HttpTransport` is now a `Service<reqwest::Request>` that we can apply
`tower::Layer` implementations on.

Currently I `Pin<Box<>>` the reqwest execute future and the
authentication future. Boxing the authentication future should be fine
as it will only happen once per request. boxing the reqwest execute
future might benefit from not having to be boxed as we can send multiple
subrequests per request, will have to figure
our how to do that at some point in the future (pun intended =).

Additionally some cases during authentication, where the upstream server caused an error, I now return 502 Bad Gateway instead of 500 or the upstream response.