### PR TITLE
feat: Add the OtlpTraceLayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,8 +587,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1138,13 +1140,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
 dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.23.0",
+ "opentelemetry_sdk 0.23.0",
  "prost",
  "tonic",
 ]
@@ -1161,9 +1177,28 @@ dependencies = [
  "futures-util",
  "lazy_static",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.23.0",
  "ordered-float",
+ "percent-encoding",
+ "rand",
  "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry 0.24.0",
+ "percent-encoding",
+ "rand",
  "thiserror",
 ]
 
@@ -1336,10 +1371,13 @@ dependencies = [
  "exitcode",
  "futures",
  "futures-util",
+ "getrandom",
  "http 1.1.0",
  "mockito",
  "oci-spec",
+ "opentelemetry 0.24.0",
  "opentelemetry-proto",
+ "opentelemetry_sdk 0.24.1",
  "pin-project",
  "prost",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -637,6 +637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,14 +1042,18 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e423c4f827362c0d8d8da4b1f571270f389ebde73bcd3240a3d23c6d6f61d0f0"
+checksum = "3f5a3fe998d50101ae009351fec56d88a69f4ed182e11000e711068c2f5abf72"
 dependencies = [
  "derive_builder",
  "getset",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "thiserror",
 ]
 
@@ -1741,6 +1751,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.60",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.13.2",
+ "prost",
  "tonic",
 ]
 
@@ -1275,35 +1275,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
 dependencies = [
  "bytes",
- "prost-derive 0.13.2",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn 2.0.60",
+ "prost-derive",
 ]
 
 [[package]]
@@ -1342,7 +1319,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "pin-project",
- "prost 0.12.6",
+ "prost",
  "regex",
  "reqwest",
  "serde",
@@ -2044,7 +2021,7 @@ dependencies = [
  "http-body-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.2",
+ "prost",
  "tokio-stream",
  "tower-layer",
  "tower-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,8 +120,8 @@ dependencies = [
  "axum-macros",
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "http-body-util",
  "itoa",
  "matchit",
@@ -147,8 +147,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -190,12 +190,6 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -622,7 +616,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -650,17 +644,6 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -672,23 +655,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -699,8 +671,8 @@ checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -735,8 +707,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -753,7 +725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
@@ -788,8 +760,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "hyper",
  "pin-project-lite",
  "socket2",
@@ -969,8 +941,8 @@ dependencies = [
  "bytes",
  "colored",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -992,7 +964,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.1.0",
+ "http",
  "httparse",
  "memchr",
  "mime",
@@ -1127,20 +1099,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
@@ -1155,34 +1113,14 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
+checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
 dependencies = [
- "opentelemetry 0.23.0",
- "opentelemetry_sdk 0.23.0",
- "prost",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.13.2",
  "tonic",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "lazy_static",
- "once_cell",
- "opentelemetry 0.23.0",
- "ordered-float",
- "percent-encoding",
- "rand",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -1196,19 +1134,11 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "percent-encoding",
  "rand",
+ "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "ordered-float"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1340,7 +1270,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.2",
 ]
 
 [[package]]
@@ -1348,6 +1288,19 @@ name = "prost-derive"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1365,21 +1318,21 @@ dependencies = [
  "async-trait",
  "axum",
  "base16ct",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "console_error_panic_hook",
  "exitcode",
  "futures",
  "futures-util",
  "getrandom",
- "http 1.1.0",
+ "http",
  "mockito",
  "oci-spec",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry_sdk",
  "pin-project",
- "prost",
+ "prost 0.12.6",
  "regex",
  "reqwest",
  "serde",
@@ -1498,14 +1451,14 @@ version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -1590,7 +1543,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "rustls-pki-types",
 ]
 
@@ -2050,19 +2003,19 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
+ "base64",
  "bytes",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http",
+ "http-body",
+ "http-body-util",
  "percent-encoding",
  "pin-project",
- "prost",
- "tokio",
+ "prost 0.13.2",
  "tokio-stream",
  "tower-layer",
  "tower-service",
@@ -2590,8 +2543,8 @@ dependencies = [
  "chrono",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "js-sys",
  "matchit",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures = "0.3.30"
 opentelemetry = { version = "*", default-features = false, features = ["trace"] }
 opentelemetry-proto = { version = "0.7.0", default-features = false, features = ["gen-tonic-messages", "logs", "trace"] }
 tracing-core = "0.1.32"
-prost = "0.12.6"
+prost = "0.13.2"
 tower = {version = "0.5.0", features = ["util"]}
 async-trait = "0.1.81"
 pin-project = "1.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,24 +45,20 @@ wasm-bindgen = "0.2.93"
 worker = { version = "0.3.0", features = ["http"] }
 tracing-web = "0.1.3"
 futures = "0.3.30"
+getrandom = { version = "*", features = ["js"] }
 
 # OTLP dependencies
-opentelemetry = { version = "*", default-features = false, features = ["trace"] }
 opentelemetry-proto = { version = "0.7.0", default-features = false, features = ["gen-tonic-messages", "logs", "trace"] }
+# sub-dependencies of opentelemetry-proto, here to disable the default features
+opentelemetry = { version = "*", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "*", default-features = false, features = ["trace"] }
+
 tracing-core = "0.1.32"
 prost = "0.13.2"
 tower = {version = "0.5.0", features = ["util"]}
 async-trait = "0.1.81"
 pin-project = "1.1.5"
 
-[dependencies.opentelemetry_sdk]
-version = "*"
-default-features = false
-features = ["trace"]
-
-[dependencies.getrandom]
-version = "*"
-features = ["js"]
 
 [dependencies.web-sys]
 version = "0.3.63"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ codegen-units = 1
 [dependencies]
 bytes = "1.7.1"
 exitcode = "1.1.2"
-oci-spec = { version = "0.6.4", default-features = false, features = ["image", "distribution"] }
+oci-spec = { version = "0.6.8", default-features = false, features = ["image", "distribution"] }
 url = "2.5.2"
 regex = "1.10.6"
 tracing = "0.1.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ tracing-web = "0.1.3"
 futures = "0.3.30"
 
 # OTLP dependencies
-opentelemetry-proto = { version ="0.6.0", features = ["gen-tonic-messages", "logs", "trace"] }
+opentelemetry = { version = "*", default-features = false, features = ["trace"] }
+opentelemetry-proto = { version = "0.7.0", default-features = false, features = ["gen-tonic-messages", "logs", "trace"] }
 tracing-core = "0.1.32"
 prost = "0.12.6"
 tower = {version = "0.5.0", features = ["util"]}
 async-trait = "0.1.81"
 pin-project = "1.1.5"
-opentelemetry = { version = "*", default-features = false, features = ["trace"] }
 
 [dependencies.opentelemetry_sdk]
 version = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,22 @@ tracing-web = "0.1.3"
 futures = "0.3.30"
 
 # OTLP dependencies
-opentelemetry-proto = { version ="0.6.0", features = ["gen-tonic-messages", "logs"] }
+opentelemetry-proto = { version ="0.6.0", features = ["gen-tonic-messages", "logs", "trace"] }
 tracing-core = "0.1.32"
 prost = "0.12.6"
 tower = {version = "0.5.0", features = ["util"]}
 async-trait = "0.1.81"
 pin-project = "1.1.5"
+opentelemetry = { version = "*", default-features = false, features = ["trace"] }
+
+[dependencies.opentelemetry_sdk]
+version = "*"
+default-features = false
+features = ["trace"]
+
+[dependencies.getrandom]
+version = "*"
+features = ["js"]
 
 [dependencies.web-sys]
 version = "0.3.63"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -7,8 +7,8 @@ services:
       - 5000:5000
     restart: always
     volumes:
-      - ./config/config.yaml:/etc/docker/registry/config.yml
-      - ./config/tls:/etc/docker/registry/certs
+      - ./config/config.yaml:/etc/docker/registry/config.yml:Z
+      - ./config/tls:/etc/docker/registry/certs:Z
 
   registry-ui:
     image: joxit/docker-registry-ui:latest

--- a/docs/examples/justfile
+++ b/docs/examples/justfile
@@ -1,6 +1,7 @@
 
 
 # Publish using the `poetry` package manager
+[group("poetry")]
 poetry-publish version username="" token="" repository="https://pyoci.allexveldman.nl/ghcr.io/allexveldman/":
     #!/usr/bin/env bash
     set -exuo pipefail
@@ -11,6 +12,7 @@ poetry-publish version username="" token="" repository="https://pyoci.allexveldm
     poetry build
     poetry publish -n -r pyoci -u "{{username}}" -p "{{token}}"
 
+[group("poetry")]
 poetry-install version username="" token="" repository="https://pyoci.allexveldman.nl/ghcr.io/allexveldman/":
     #!/usr/bin/env bash
     set -exuo pipefail
@@ -25,7 +27,7 @@ poetry-install version username="" token="" repository="https://pyoci.allexveldm
     poetry add "hello-world@{{version}}" --source pyoci --no-cache
     poetry run python -m hello_world
 
-
+[group("curl")]
 curl-publish version username token repository="http://localhost:8090/ghcr.io/allexveldman/":
     #!/usr/bin/env bash
     set -exuo pipefail
@@ -44,9 +46,11 @@ curl-publish version username token repository="http://localhost:8090/ghcr.io/al
     -F version={{version}} \
     -F content=@dist/hello_world-{{version}}.tar.gz
 
+[group("curl")]
 curl-list username token repository="http://localhost:8090/ghcr.io/allexveldman/":
     curl -v -u {{username}}:{{token}} {{repository}}hello-world/
 
+[group("curl")]
 curl-download version username token repository="http://localhost:8090/ghcr.io/allexveldman/":
     curl -vOJ -u {{username}}:{{token}} {{repository}}hello_world/hello_world-{{version}}.tar.gz
     rm hello_world-{{version}}.tar.gz

--- a/justfile
+++ b/justfile
@@ -28,5 +28,7 @@ refresh-registry:
 # Run a smoketest on a local pyoci instance and a local OCI registry
 [group("test")]
 test-smoke: refresh-registry
+    @lsof -i -P | grep "5000 (LISTEN)" || { echo "docker registry is not listening on port 5000"; exit 1; }
+    @lsof -i -P | grep "8090 (LISTEN)" || { echo "pyoci is not listening on port 8090"; exit 1; }
     just examples::poetry-publish "0.1.0+1234" "" "" "http://localhost:8090/http%3A%2F%2Flocalhost%3A5000/pyoci/"
     just examples::poetry-install "0.1.0+1234" "" "" "http://localhost:8090/http%3A%2F%2Flocalhost%3A5000/pyoci/"

--- a/src/app.rs
+++ b/src/app.rs
@@ -87,6 +87,7 @@ async fn accesslog_middleware(
 //  Because the cloudflare worker runtime is single-threaded, we can safely mark this as Send
 //  https://docs.rs/worker/latest/worker/index.html#send-helpers
 #[cfg_attr(target_arch = "wasm32", worker::send)]
+#[tracing::instrument(skip_all)]
 async fn list_package(
     headers: HeaderMap,
     Host(host): Host,
@@ -116,6 +117,7 @@ async fn list_package(
 //  Because the cloudflare worker runtime is single-threaded, we can safely mark this as Send
 //  https://docs.rs/worker/latest/worker/index.html#send-helpers
 #[cfg_attr(target_arch = "wasm32", worker::send)]
+#[tracing::instrument(skip_all)]
 async fn download_package(
     path_params: Path<(String, String, Option<String>, String)>,
     headers: HeaderMap,
@@ -152,6 +154,7 @@ async fn download_package(
 //  Because the cloudflare worker runtime is single-threaded, we can safely mark this as Send
 //  https://docs.rs/worker/latest/worker/index.html#send-helpers
 #[cfg_attr(target_arch = "wasm32", worker::send)]
+#[tracing::instrument(skip_all)]
 async fn publish_package(
     Path((registry, namespace)): Path<(String, String)>,
     headers: HeaderMap,

--- a/src/app.rs
+++ b/src/app.rs
@@ -629,6 +629,7 @@ mod tests {
             server
                 .mock("PUT", "/v2/mockserver/foobar/manifests/sha256:7ffd96d9eab411893eeacfa906e30956290a07b0141d7c1dd54c9fd5c7c48cf5")
                 .match_header("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+                .match_body(r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":"application/pyoci.package.v1","config":{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2},"layers":[{"mediaType":"application/pyoci.package.v1","digest":"sha256:b7513fb69106a855b69153582dec476677b3c79f4a13cfee6fb7a356cfa754c0","size":22}]}"#)
                 .with_status(201) // CREATED
                 .create_async()
                 .await,
@@ -636,6 +637,7 @@ mod tests {
             server
                 .mock("PUT", "/v2/mockserver/foobar/manifests/1.0.0")
                 .match_header("Content-Type", "application/vnd.oci.image.index.v1+json")
+                .match_body(r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","artifactType":"application/pyoci.package.v1","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:7ffd96d9eab411893eeacfa906e30956290a07b0141d7c1dd54c9fd5c7c48cf5","size":422,"platform":{"architecture":".tar.gz","os":"any"}}]}"#)
                 .with_status(201) // CREATED
                 .create_async()
                 .await,

--- a/src/cf.rs
+++ b/src/cf.rs
@@ -16,8 +16,8 @@ fn start() {
     console_error_panic_hook::set_once();
 }
 
-fn init(env: &Env) -> &'static Option<crate::otlp::OtlpLogLayer> {
-    static INIT: OnceLock<Option<crate::otlp::OtlpLogLayer>> = OnceLock::new();
+fn init(env: &Env) -> &'static crate::otlp::OtlpLayer {
+    static INIT: OnceLock<crate::otlp::OtlpLayer> = OnceLock::new();
     INIT.get_or_init(|| {
         let rust_log = match env.var("RUST_LOG") {
             Ok(log) => log.to_string(),
@@ -33,22 +33,30 @@ fn init(env: &Env) -> &'static Option<crate::otlp::OtlpLogLayer> {
 
         let registry = tracing_subscriber::registry().with(fmt_layer);
 
-        let otlp_layer = if let (Ok(otlp_endpoint), Ok(otlp_auth)) =
+        let (log_layer, trace_layer) = if let (Ok(otlp_endpoint), Ok(otlp_auth)) =
             (env.secret("OTLP_ENDPOINT"), env.secret("OTLP_AUTH"))
         {
-            Some(crate::otlp::OtlpLogLayer::new(
-                otlp_endpoint.to_string(),
-                otlp_auth.to_string(),
-            ))
+            let log_layer =
+                crate::otlp::OtlpLogLayer::new(otlp_endpoint.to_string(), otlp_auth.to_string());
+            let trace_layer =
+                crate::otlp::OtlpTraceLayer::new(otlp_endpoint.to_string(), otlp_auth.to_string());
+            (Some(log_layer), Some(trace_layer))
         } else {
-            None
+            (None, None)
         };
 
         registry
-            .with(otlp_layer.clone().with_filter(EnvFilter::new(rust_log)))
+            .with(crate::otlp::SpanTimeLayer::new())
+            .with(
+                trace_layer
+                    .clone()
+                    .with_filter(EnvFilter::new(rust_log.clone())),
+            )
+            .with(log_layer.clone().with_filter(EnvFilter::new(rust_log)))
             .init();
         console_log!("Worker initialized");
-        otlp_layer
+        // TODO: combine otlp layer so we can flush as one.
+        (log_layer, trace_layer)
     })
 }
 
@@ -64,14 +72,15 @@ async fn fetch(
 
     let span = info_span!("fetch", path = %req.uri().path(), method = %req.method());
     let result = crate::app::router().call(req).instrument(span).await;
-    if let Some(otlp_layer) = otlp_layer {
+    if let (Some(log_layer), Some(trace_layer)) = otlp_layer {
         let attributes = HashMap::from([
             ("service.name", Some("pyoci".to_string())),
             ("cloud.region", cf.region()),
             ("cloud.availability_zone", Some(cf.colo())),
         ]);
         ctx.wait_until(async move {
-            otlp_layer.flush(&attributes).await;
+            log_layer.flush(&attributes).await;
+            trace_layer.flush(&attributes).await;
         });
     }
     Ok(result?)

--- a/src/otlp/log.rs
+++ b/src/otlp/log.rs
@@ -194,7 +194,7 @@ impl Visit for LogVisitor {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::otlp::SpanIdLayer;
 
     use super::*;

--- a/src/otlp/log.rs
+++ b/src/otlp/log.rs
@@ -17,6 +17,7 @@ use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
 use opentelemetry_proto::tonic::resource::v1::Resource;
 
+use crate::otlp::Toilet;
 use crate::USER_AGENT;
 
 /// Convert a batch of log records into a ExportLogsServiceRequest
@@ -77,11 +78,10 @@ impl OtlpLogLayer {
     }
 }
 
-// Private methods
-impl OtlpLogLayer {
+impl Toilet for OtlpLogLayer {
     /// Push all recorded log messages to the OTLP collector
     /// This should be called at the end of every request, after the span is closed
-    pub async fn flush(&self, attributes: &HashMap<&str, Option<String>>) {
+    async fn flush(&self, attributes: &HashMap<&str, Option<String>>) {
         let records: Vec<LogRecord> = self.records.write().unwrap().drain(..).collect();
         if records.is_empty() {
             return;

--- a/src/otlp/log.rs
+++ b/src/otlp/log.rs
@@ -157,7 +157,6 @@ where
         let log_record = LogRecord {
             time_unix_nano: time_ns,
             observed_time_unix_nano: time_ns,
-            severity_number: severity_number(level),
             severity_text: level.to_string().to_uppercase(),
             body: Some(AnyValue {
                 value: Some(any_value::Value::StringValue(visitor.string)),
@@ -179,16 +178,6 @@ fn time_unix_ns() -> Option<u64> {
             tracing::info!("SystemTime out of range for conversion to u64!");
             None
         }
-    }
-}
-
-fn severity_number(level: &tracing::Level) -> i32 {
-    match *level {
-        tracing::Level::ERROR => 17,
-        tracing::Level::WARN => 13,
-        tracing::Level::INFO => 9,
-        tracing::Level::DEBUG => 5,
-        tracing::Level::TRACE => 1,
     }
 }
 

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -1,9 +1,65 @@
 mod log;
 mod trace;
 
+use std::collections::HashMap;
+
 pub use log::OtlpLogLayer;
 pub use trace::OtlpTraceLayer;
 pub use trace::SpanIdLayer;
 pub use trace::SpanTimeLayer;
+use tracing::Subscriber;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::LookupSpan;
 
 pub type OtlpLayer = (Option<OtlpLogLayer>, Option<OtlpTraceLayer>);
+
+pub fn otlp<S>(
+    subscriber: S,
+    otlp_endpoint: Option<String>,
+    otlp_auth: Option<String>,
+) -> (impl Subscriber, OtlpLayer)
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let (log_layer, trace_layer) = if let (Some(otlp_endpoint), Some(otlp_auth)) =
+        (otlp_endpoint, otlp_auth)
+    {
+        let log_layer = crate::otlp::OtlpLogLayer::new(otlp_endpoint.clone(), otlp_auth.clone());
+        let trace_layer = crate::otlp::OtlpTraceLayer::new(otlp_endpoint, otlp_auth);
+        (Some(log_layer), Some(trace_layer))
+    } else {
+        (None, None)
+    };
+
+    (
+        subscriber
+            .with(SpanIdLayer::default())
+            .with(SpanTimeLayer::default())
+            .with(log_layer.clone())
+            .with(trace_layer.clone()),
+        (log_layer, trace_layer),
+    )
+}
+
+pub trait Toilet {
+    async fn flush(&self, _attributes: &HashMap<&str, Option<String>>) {}
+}
+
+impl<T> Toilet for Option<T>
+where
+    T: Toilet,
+{
+    async fn flush(&self, attributes: &HashMap<&str, Option<String>>) {
+        match self {
+            Some(toilet) => toilet.flush(attributes).await,
+            None => (),
+        }
+    }
+}
+
+impl Toilet for OtlpLayer {
+    async fn flush(&self, attributes: &HashMap<&str, Option<String>>) {
+        self.0.flush(attributes).await;
+        self.1.flush(attributes).await;
+    }
+}

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -48,7 +48,7 @@ where
 }
 
 pub trait Toilet {
-    async fn flush(&self, _attributes: &HashMap<&str, Option<String>>) {}
+    async fn flush(&self, _attributes: &HashMap<&str, Option<String>>);
 }
 
 impl<T> Toilet for Option<T>

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -1,0 +1,8 @@
+mod log;
+mod trace;
+
+pub use log::OtlpLogLayer;
+pub use trace::OtlpTraceLayer;
+pub use trace::SpanTimeLayer;
+
+pub type OtlpLayer = (Option<OtlpLogLayer>, Option<OtlpTraceLayer>);

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -3,6 +3,7 @@ mod trace;
 
 pub use log::OtlpLogLayer;
 pub use trace::OtlpTraceLayer;
+pub use trace::SpanIdLayer;
 pub use trace::SpanTimeLayer;
 
 pub type OtlpLayer = (Option<OtlpLogLayer>, Option<OtlpTraceLayer>);

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -3,16 +3,22 @@ mod trace;
 
 use std::collections::HashMap;
 
-pub use log::OtlpLogLayer;
-pub use trace::OtlpTraceLayer;
-pub use trace::SpanIdLayer;
-pub use trace::SpanTimeLayer;
+use log::OtlpLogLayer;
+use trace::OtlpTraceLayer;
+use trace::SpanIdLayer;
+use trace::SpanTimeLayer;
 use tracing::Subscriber;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::LookupSpan;
 
 pub type OtlpLayer = (Option<OtlpLogLayer>, Option<OtlpTraceLayer>);
 
+/// Wrap `subscriber` with OTLP tracing.
+/// Note that this adds 4 types to every trace's extensions:
+/// - [TraceId](opentelemetry::trace::TraceId) - ID shared by all nested spans
+/// - [SpanId](opentelemetry::trace::SpanId) - ID of this span
+/// - [SpanStart](trace::SpanStart) - Unix timestamp [ns] when the span was first entered
+/// - [SpanEnd](trace::SpanEnd) - Unix timestamp [ns] when the span was last exited
 pub fn otlp<S>(
     subscriber: S,
     otlp_endpoint: Option<String>,

--- a/src/otlp/trace.rs
+++ b/src/otlp/trace.rs
@@ -18,7 +18,6 @@ use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_sdk::trace::{IdGenerator, RandomIdGenerator};
 
-use super::log::log;
 use crate::USER_AGENT;
 
 /// <https://opentelemetry.io/docs/specs/otlp/#otlpgrpc>
@@ -58,6 +57,8 @@ fn build_trace_export_body(
 }
 
 /// Tracing Layer for pushing logs to an OTLP consumer.
+/// Requires a [TraceId] and [SpanId] to be present in Trace Extensions, see [SpanIdLayer].
+/// Requires [SpanStart] and [SpanEnd] to be present in the Trace Extensions, see [SpanTimeLayer].
 #[derive(Debug, Clone)]
 pub struct OtlpTraceLayer {
     otlp_endpoint: String,
@@ -84,10 +85,10 @@ impl OtlpTraceLayer {
     pub async fn flush(&self, attributes: &HashMap<&str, Option<String>>) {
         let spans: Vec<Span> = self.spans.write().unwrap().drain(..).collect();
         if spans.is_empty() {
-            log!("No spans to send");
+            tracing::info!("No spans to send");
             return;
         }
-        log!("Sending {} spans to OTLP", spans.len());
+        tracing::info!("Sending {} spans to OTLP", spans.len());
         let client = reqwest::Client::builder()
             .user_agent(USER_AGENT)
             .build()
@@ -107,14 +108,14 @@ impl OtlpTraceLayer {
         {
             Ok(response) => {
                 if !response.status().is_success() {
-                    log!("Failed to send traces to OTLP: {:?}", response);
-                    log!("Response body: {:?}", response.text().await.unwrap());
+                    tracing::info!("Failed to send traces to OTLP: {:?}", response);
+                    tracing::info!("Response body: {:?}", response.text().await.unwrap());
                 } else {
-                    log!("Traces sent to OTLP: {:?}", response);
+                    tracing::info!("Traces sent to OTLP: {:?}", response);
                 };
             }
             Err(err) => {
-                log!("Error sending traces to OTLP: {:?}", err);
+                tracing::info!("Error sending traces to OTLP: {:?}", err);
             }
         };
     }
@@ -124,50 +125,29 @@ impl<S> Layer<S> for OtlpTraceLayer
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    /// Add TraceId and SpanId to the span extensions
-    fn on_new_span(&self, _attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
-        let Some(span) = ctx.span(id) else {
-            log!("Span {id:?} does not exist");
-            return;
-        };
-        let mut extensions = span.extensions_mut();
-        let rng = RandomIdGenerator::default();
-        extensions.insert(rng.new_span_id());
-
-        match span.parent() {
-            None => extensions.insert(rng.new_trace_id()),
-            Some(parent) => extensions.insert(
-                *parent
-                    .extensions()
-                    .get::<TraceId>()
-                    .expect("TraceId not set, this is a bug"),
-            ),
-        }
-    }
-
     fn on_close(&self, id: Id, ctx: Context<'_, S>) {
         let Some(span) = ctx.span(&id) else {
-            log!("Span {id:?} does not exist");
+            tracing::info!("Span {id:?} does not exist");
             return;
         };
         let extensions = span.extensions();
         let Some(start_time) = extensions.get::<SpanStart>() else {
-            log!("SpanStart not defined for Span {id:?}");
+            tracing::info!("SpanStart not defined for Span {id:?}");
             return;
         };
         let Some(end_time) = extensions.get::<SpanEnd>() else {
-            log!("SpanEnd not defined for Span {id:?}");
+            tracing::info!("SpanEnd not defined for Span {id:?}");
             return;
         };
 
         let extensions = span.extensions();
         let Some(trace_id) = extensions.get::<TraceId>() else {
-            log!("Could not find Trace ID for Span {id:?}");
+            tracing::info!("Could not find Trace ID for Span {id:?}");
             return;
         };
 
         let Some(span_id) = extensions.get::<SpanId>() else {
-            log!("Could not find Span ID for Span {id:?}");
+            tracing::info!("Could not find Span ID for Span {id:?}");
             return;
         };
 
@@ -211,7 +191,7 @@ fn time_unix_ns() -> Option<u64> {
     match OffsetDateTime::now_utc().unix_timestamp_nanos().try_into() {
         Ok(value) => Some(value),
         Err(_) => {
-            log!("SystemTime out of range for conversion to u64!");
+            tracing::info!("SystemTime out of range for conversion to u64!");
             None
         }
     }
@@ -236,12 +216,8 @@ impl From<&SpanEnd> for u64 {
 }
 
 /// Inject span timings into the span extensions, required by OtlpTraceLayer
+#[derive(Debug, Default)]
 pub struct SpanTimeLayer {}
-impl SpanTimeLayer {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
 
 impl<S> Layer<S> for SpanTimeLayer
 where
@@ -266,5 +242,34 @@ where
             return;
         };
         span.extensions_mut().replace::<SpanEnd>(current_time);
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SpanIdLayer {
+    rng: RandomIdGenerator,
+}
+
+impl<S> Layer<S> for SpanIdLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, _attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else {
+            tracing::info!("Span {id:?} does not exist");
+            return;
+        };
+        let mut extensions = span.extensions_mut();
+        extensions.insert(self.rng.new_span_id());
+
+        match span.parent() {
+            None => extensions.insert(self.rng.new_trace_id()),
+            Some(parent) => extensions.insert(
+                *parent
+                    .extensions()
+                    .get::<TraceId>()
+                    .expect("TraceId not set, this is a bug"),
+            ),
+        }
     }
 }

--- a/src/otlp/trace.rs
+++ b/src/otlp/trace.rs
@@ -18,6 +18,7 @@ use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_sdk::trace::{IdGenerator, RandomIdGenerator};
 
+use crate::otlp::Toilet;
 use crate::USER_AGENT;
 
 /// <https://opentelemetry.io/docs/specs/otlp/#otlpgrpc>
@@ -79,10 +80,10 @@ impl OtlpTraceLayer {
 }
 
 // Private methods
-impl OtlpTraceLayer {
+impl Toilet for OtlpTraceLayer {
     /// Push all recorded log messages to the OTLP collector
     /// This should be called at the end of every request, after the span is closed
-    pub async fn flush(&self, attributes: &HashMap<&str, Option<String>>) {
+    async fn flush(&self, attributes: &HashMap<&str, Option<String>>) {
         let spans: Vec<Span> = self.spans.write().unwrap().drain(..).collect();
         if spans.is_empty() {
             tracing::info!("No spans to send");

--- a/src/otlp/trace.rs
+++ b/src/otlp/trace.rs
@@ -326,7 +326,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use super::*;
     use tracing::dispatcher;

--- a/src/otlp/trace.rs
+++ b/src/otlp/trace.rs
@@ -1,0 +1,270 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use opentelemetry_proto::tonic::trace::v1::span::SpanKind;
+use opentelemetry_proto::tonic::trace::v1::status::StatusCode;
+use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span, Status};
+use prost::Message;
+use time::OffsetDateTime;
+use tracing::span::Attributes;
+use tracing::Id;
+use tracing::Subscriber;
+use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+
+use opentelemetry::trace::{SpanId, TraceId};
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use opentelemetry_proto::tonic::common::v1::any_value;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use opentelemetry_sdk::trace::{IdGenerator, RandomIdGenerator};
+
+use super::log::log;
+use crate::USER_AGENT;
+
+/// <https://opentelemetry.io/docs/specs/otlp/#otlpgrpc>
+fn build_trace_export_body(
+    spans: Vec<Span>,
+    attributes: &HashMap<&str, Option<String>>,
+) -> ExportTraceServiceRequest {
+    let scope_spans = ScopeSpans {
+        scope: None,
+        spans,
+        schema_url: "".to_string(),
+    };
+
+    let mut attrs = vec![];
+    for (key, value) in attributes {
+        let Some(value) = value else {
+            continue;
+        };
+        attrs.push(KeyValue {
+            key: (*key).into(),
+            value: Some(AnyValue {
+                value: Some(any_value::Value::StringValue(value.into())),
+            }),
+        });
+    }
+    let resource_spans = ResourceSpans {
+        resource: Some(Resource {
+            attributes: attrs,
+            dropped_attributes_count: 0,
+        }),
+        scope_spans: vec![scope_spans],
+        schema_url: "".to_string(),
+    };
+    ExportTraceServiceRequest {
+        resource_spans: vec![resource_spans],
+    }
+}
+
+/// Tracing Layer for pushing logs to an OTLP consumer.
+#[derive(Debug, Clone)]
+pub struct OtlpTraceLayer {
+    otlp_endpoint: String,
+    otlp_auth: String,
+    /// Buffer of Spans
+    spans: Arc<RwLock<Vec<Span>>>,
+}
+
+// Public methods
+impl OtlpTraceLayer {
+    pub fn new(otlp_endpoint: String, otlp_auth: String) -> Self {
+        Self {
+            otlp_endpoint,
+            otlp_auth,
+            spans: Arc::new(RwLock::new(vec![])),
+        }
+    }
+}
+
+// Private methods
+impl OtlpTraceLayer {
+    /// Push all recorded log messages to the OTLP collector
+    /// This should be called at the end of every request, after the span is closed
+    pub async fn flush(&self, attributes: &HashMap<&str, Option<String>>) {
+        let spans: Vec<Span> = self.spans.write().unwrap().drain(..).collect();
+        if spans.is_empty() {
+            log!("No spans to send");
+            return;
+        }
+        log!("Sending {} spans to OTLP", spans.len());
+        let client = reqwest::Client::builder()
+            .user_agent(USER_AGENT)
+            .build()
+            .unwrap();
+
+        let body = build_trace_export_body(spans, attributes).encode_to_vec();
+        let mut url = url::Url::parse(&self.otlp_endpoint).unwrap();
+        url.path_segments_mut().unwrap().extend(&["v1", "traces"]);
+        // send to OTLP Collector
+        match client
+            .post(url)
+            .header("Content-Type", "application/x-protobuf")
+            .header("Authorization", &self.otlp_auth)
+            .body(body)
+            .send()
+            .await
+        {
+            Ok(response) => {
+                if !response.status().is_success() {
+                    log!("Failed to send traces to OTLP: {:?}", response);
+                    log!("Response body: {:?}", response.text().await.unwrap());
+                } else {
+                    log!("Traces sent to OTLP: {:?}", response);
+                };
+            }
+            Err(err) => {
+                log!("Error sending traces to OTLP: {:?}", err);
+            }
+        };
+    }
+}
+
+impl<S> Layer<S> for OtlpTraceLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    /// Add TraceId and SpanId to the span extensions
+    fn on_new_span(&self, _attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else {
+            log!("Span {id:?} does not exist");
+            return;
+        };
+        let mut extensions = span.extensions_mut();
+        let rng = RandomIdGenerator::default();
+        extensions.insert(rng.new_span_id());
+
+        match span.parent() {
+            None => extensions.insert(rng.new_trace_id()),
+            Some(parent) => extensions.insert(
+                *parent
+                    .extensions()
+                    .get::<TraceId>()
+                    .expect("TraceId not set, this is a bug"),
+            ),
+        }
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(&id) else {
+            log!("Span {id:?} does not exist");
+            return;
+        };
+        let extensions = span.extensions();
+        let Some(start_time) = extensions.get::<SpanStart>() else {
+            log!("SpanStart not defined for Span {id:?}");
+            return;
+        };
+        let Some(end_time) = extensions.get::<SpanEnd>() else {
+            log!("SpanEnd not defined for Span {id:?}");
+            return;
+        };
+
+        let extensions = span.extensions();
+        let Some(trace_id) = extensions.get::<TraceId>() else {
+            log!("Could not find Trace ID for Span {id:?}");
+            return;
+        };
+
+        let Some(span_id) = extensions.get::<SpanId>() else {
+            log!("Could not find Span ID for Span {id:?}");
+            return;
+        };
+
+        let parent_span_id = span
+            .parent()
+            .map(|p_span| p_span.extensions().get::<SpanId>().map(|id| id.to_bytes()))
+            .unwrap_or_default()
+            .unwrap_or_default()
+            .into();
+
+        let span = Span {
+            trace_id: trace_id.to_bytes().into(),
+            span_id: span_id.to_bytes().into(),
+            parent_span_id,
+            trace_state: "".to_string(),
+            flags: 0,
+            name: span.name().to_string(),
+            // TODO: fetch this from the span fields
+            kind: SpanKind::Internal.into(),
+            start_time_unix_nano: start_time.into(),
+            end_time_unix_nano: end_time.into(),
+            //TODO: Add attrs from span.fields
+            attributes: vec![],
+            dropped_attributes_count: 0,
+            // Are these the logs?
+            events: vec![],
+            dropped_events_count: 0,
+            links: vec![],
+            dropped_links_count: 0,
+            status: Some(Status {
+                message: "".to_string(),
+                code: StatusCode::Ok.into(),
+            }),
+        };
+
+        self.spans.write().unwrap().push(span);
+    }
+}
+
+fn time_unix_ns() -> Option<u64> {
+    match OffsetDateTime::now_utc().unix_timestamp_nanos().try_into() {
+        Ok(value) => Some(value),
+        Err(_) => {
+            log!("SystemTime out of range for conversion to u64!");
+            None
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SpanStart(u64);
+
+#[derive(Debug)]
+struct SpanEnd(u64);
+
+impl From<&SpanStart> for u64 {
+    fn from(value: &SpanStart) -> u64 {
+        value.0
+    }
+}
+
+impl From<&SpanEnd> for u64 {
+    fn from(value: &SpanEnd) -> u64 {
+        value.0
+    }
+}
+
+/// Inject span timings into the span extensions, required by OtlpTraceLayer
+pub struct SpanTimeLayer {}
+impl SpanTimeLayer {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<S> Layer<S> for SpanTimeLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    /// Insert the SpanStart when we enter this span
+    /// note that a span is entered and exited when crossing await bounds
+    /// so we should only set the start value once.
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        if span.extensions().get::<SpanStart>().is_some() {
+            return;
+        };
+        let Some(current_time) = time_unix_ns().map(SpanStart) else {
+            return;
+        };
+        span.extensions_mut().replace::<SpanStart>(current_time);
+    }
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        let Some(current_time) = time_unix_ns().map(SpanEnd) else {
+            return;
+        };
+        span.extensions_mut().replace::<SpanEnd>(current_time);
+    }
+}

--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -438,6 +438,7 @@ impl PyOci {
     /// Push a blob to the registry using POST then PUT method
     ///
     /// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#post-then-put
+    #[tracing::instrument(skip_all)]
     async fn push_blob(
         &mut self,
         // Name of the package, including namespace. e.g. "library/alpine"
@@ -516,6 +517,7 @@ impl PyOci {
     /// Pull a blob from the registry
     ///
     /// This returns the raw response so the caller can handle the blob as needed
+    #[tracing::instrument(skip_all)]
     async fn pull_blob(
         &mut self,
         // Name of the package, including namespace. e.g. "library/alpine"
@@ -535,6 +537,7 @@ impl PyOci {
     }
 
     /// List the available tags for a package
+    #[tracing::instrument(skip_all)]
     async fn list_tags(&mut self, name: &str) -> anyhow::Result<TagList> {
         let url = build_url!(&self, "/v2/{}/tags/list", name);
         let request = self.transport.get(url);
@@ -554,6 +557,7 @@ impl PyOci {
     ///
     /// ImageIndex will be pushed with a version tag if version is set
     /// ImageManifest will always be pushed with a digest reference
+    #[tracing::instrument(skip_all)]
     async fn push_manifest(
         &mut self,
         name: &str,
@@ -593,6 +597,7 @@ impl PyOci {
     ///
     /// If the manifest does not exist, Ok<None> is returned
     /// If any other error happens, an Err is returned
+    #[tracing::instrument(skip_all)]
     async fn pull_manifest(&mut self, name: &str, reference: &str) -> Result<Option<Manifest>> {
         let url = build_url!(&self, "/v2/{}/manifests/{}", name, reference);
         let request = self.transport.get(url).header(

--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -568,11 +568,11 @@ impl PyOci {
             Manifest::Index(index) => {
                 let version = version.context("`version` required for pushing an ImageIndex")?;
                 let url = build_url!(&self, "v2/{}/manifests/{}", name, version);
-                let data = index.to_string();
+                let data = serde_json::to_string(&index)?;
                 (url, data, "application/vnd.oci.image.index.v1+json")
             }
             Manifest::Manifest(manifest) => {
-                let data = manifest.to_string();
+                let data = serde_json::to_string(&manifest)?;
                 let sha = <Sha256 as Digest>::digest(&data);
                 let digest = format!("sha256:{}", hex_encode(&sha));
                 let url = build_url!(&self, "/v2/{}/manifests/{}", name, &digest);

--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -568,11 +568,11 @@ impl PyOci {
             Manifest::Index(index) => {
                 let version = version.context("`version` required for pushing an ImageIndex")?;
                 let url = build_url!(&self, "v2/{}/manifests/{}", name, version);
-                let data = index.to_string().expect("valid json");
+                let data = index.to_string();
                 (url, data, "application/vnd.oci.image.index.v1+json")
             }
             Manifest::Manifest(manifest) => {
-                let data = manifest.to_string().expect("valid json");
+                let data = manifest.to_string();
                 let sha = <Sha256 as Digest>::digest(&data);
                 let digest = format!("sha256:{}", hex_encode(&sha));
                 let url = build_url!(&self, "/v2/{}/manifests/{}", name, &digest);

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -298,7 +298,7 @@ where
 /// The high-level tests for this Service are part of `src/transport.rs`.
 /// This module tests some of the error cases
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use mockito::Server;
     use reqwest::{Body, Client};

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -259,6 +259,7 @@ where
 // Returns the bearer token if successful.
 // Returns the upstream response of not.
 #[cfg_attr(target_arch = "wasm32", worker::send)]
+#[tracing::instrument(skip_all)]
 async fn authenticate<S>(
     basic_token: http::HeaderValue,
     www_auth: WwwAuth,


### PR DESCRIPTION
This layer collects and sends traces to the OTLP collector.
Trace and Span IDs are now set on Span extensions instead of reusing the
tracing generated IDs.
