### PR TITLE
chore(otlp): Set span-kind and span attributes

### DIFF
--- a/src/cf.rs
+++ b/src/cf.rs
@@ -61,7 +61,12 @@ async fn fetch(
     let otlp_layer = init(&env);
     let cf = req.extensions().get::<Cf>().unwrap().to_owned();
 
-    let span = info_span!("fetch", path = %req.uri().path(), method = %req.method());
+    let span = info_span!(
+        "fetch",
+        otel.path = req.uri().path(),
+        otel.method = req.method().as_str(),
+        otel.span_kind = "server"
+    );
     let result = crate::app::router().call(req).instrument(span).await;
     let attributes = HashMap::from([
         ("service.name", Some("pyoci".to_string())),

--- a/src/service/log.rs
+++ b/src/service/log.rs
@@ -4,7 +4,6 @@ use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use time::OffsetDateTime;
 use tower::{Layer, Service};
 
 #[derive(Debug, Default, Clone)]
@@ -59,7 +58,6 @@ where
             url: request.url().to_string(),
             inner_fut: self.inner.call(request),
             request_type: self.request_type,
-            start: OffsetDateTime::now_utc(),
         }
     }
 }
@@ -71,7 +69,6 @@ pub struct LogFuture<F> {
     method: String,
     url: String,
     request_type: &'static str,
-    start: OffsetDateTime,
 }
 
 impl<F> Future for LogFuture<F>
@@ -87,7 +84,6 @@ where
             Ok(response) => {
                 let status: u16 = response.status().into();
                 tracing::info!(
-                    elapsed_ms = (OffsetDateTime::now_utc() - *this.start).whole_milliseconds(),
                     method = this.method,
                     status,
                     url = this.url,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -42,13 +42,13 @@ impl Service<reqwest::Request> for HttpTransport {
         #[cfg(target_arch = "wasm32")]
         let fut = Box::pin(
             worker::send::SendFuture::new(self.client.execute(request))
-                .instrument(tracing::info_span!("send")),
+                .instrument(tracing::info_span!("send", otel.span_kind = "client")),
         );
         #[cfg(not(target_arch = "wasm32"))]
         let fut = Box::pin(
             self.client
                 .execute(request)
-                .instrument(tracing::info_span!("send")),
+                .instrument(tracing::info_span!("send", otel.span_kind = "client")),
         );
         fut
     }


### PR DESCRIPTION
This sets the span-kind for the "fetch" trace to "server" and the "send"
trace to "client" to make the spans more inline with their intent.

"method" and "path" are now included as span attributes.

This drops the "elapsed_ms" label in the log records, this
information is available as part of the traces.
