### PR TITLE
fix(publish): Return 409: Conflict when a version already exists

### DIFF
--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -431,11 +431,15 @@ impl PyOci {
                 for existing in index.manifests() {
                     match existing.platform() {
                         Some(platform) if *platform == manifest.platform => {
-                            bail!(
-                                "Platform '{}' already exists for version '{}'",
-                                package.oci_architecture(),
-                                tag
-                            );
+                            return Err(PyOciError::from((
+                                StatusCode::CONFLICT,
+                                format!(
+                                    "Platform '{}' already exists for version '{}'",
+                                    package.oci_architecture(),
+                                    tag
+                                ),
+                            ))
+                            .into())
                         }
                         _ => {}
                     }


### PR DESCRIPTION
This used to return 500: Internal Server Error.
