### PR TITLE
refactor(package): Rewrite of `package::Info`

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,8 +1,8 @@
-use crate::package::Info;
+use crate::package::{Package, WithFile};
 use askama::Template;
 
 #[derive(Template)]
 #[template(path = "list-package.html")]
-pub struct ListPackageTemplate {
-    pub files: Vec<Info>,
+pub struct ListPackageTemplate<'a> {
+    pub files: Vec<Package<'a, WithFile>>,
 }


### PR DESCRIPTION
Rename `Info` to `Package`.

The new `Package` is simpler in structure and utilizes type state to ensure the `version` and `arch` fields can only be used in the appropriate context.

The `registry` and `namespace` fields are no longer owned by `Package` as they never change and won't outlive the lifetime of the request. This prevents multiple clones, especially in `list_package_files`.