### PR TITLE
feat: Add `<>/<>/<>/json` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,8 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
  "sync_wrapper 1.0.1",
  "tokio",
  "tower 0.4.13",
@@ -1446,6 +1448,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ async-trait = "0.1.83"
 pin-project = "1.1.5"
 futures = "0.3.30"
 time = "0.3.36"
-axum = { version = "0.7.5", default-features = false, features = ["multipart","macros", "tokio", "http1"] }
+axum = { version = "0.7.5", default-features = false, features = ["multipart","macros", "tokio", "http1", "json"] }
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "signal", "time"] }
 tokio-util = "0.7.12"
 

--- a/docs/examples/justfile
+++ b/docs/examples/justfile
@@ -51,6 +51,10 @@ curl-list username token repository="http://localhost:8080/ghcr.io/allexveldman/
     curl -v -u {{username}}:{{token}} {{repository}}hello-world/
 
 [group("curl")]
+curl-list-json username token repository="http://localhost:8080/ghcr.io/allexveldman/":
+    curl -v -u {{username}}:{{token}} {{repository}}hello-world/json
+
+[group("curl")]
 curl-download version username token repository="http://localhost:8080/ghcr.io/allexveldman/":
     curl -vOJ -u {{username}}:{{token}} {{repository}}hello_world/hello_world-{{version}}.tar.gz
     rm hello_world-{{version}}.tar.gz

--- a/src/package.rs
+++ b/src/package.rs
@@ -94,6 +94,11 @@ impl<T: FileState> Package<'_, T> {
         }
     }
 
+    /// Name of the package
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     /// Name of the package as used for the OCI registry
     ///
     /// The package is in the format `<namespace>/<name>`

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -55,7 +55,7 @@ impl HttpTransport {
     pub fn new(auth: Option<String>) -> Result<Self> {
         let client = reqwest::Client::builder().user_agent(USER_AGENT);
         Ok(Self {
-            client: client.build()?,
+            client: client.build().unwrap(),
             auth_layer: AuthLayer::new(auth)?,
         })
     }


### PR DESCRIPTION
Adds minimal support for the [JSON API](https://warehouse.pypa.io/api-reference/json.html). This saves sub-requests when Renovate queries for package versions.