### PR TITLE
feat: Delete package version

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,3 +1,4 @@
+# Run the examples against the (just deployed) live environment
 name: Examples
 
 on:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -60,9 +60,20 @@ jobs:
           file: docker/Dockerfile
           cache-from: type=registry,ref=ghcr.io/allexveldman/pyoci:latest
           cache-to: type=inline
+          load: true
           push: ${{ github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # Smoke-test the image
+      # The smoke test contains a build of the image but because the previous
+      # step defines `load: true` the entire build will be from cache.
+      - uses: extractions/setup-just@v2
+      - uses: snok/install-poetry@v1
+      - name: Smoke Test
+        run: just test-smoke
+      - run: docker compose logs pyoci
+        working-directory: ./docker
 
   deploy:
     name: Deploy

--- a/docker/config/config.yaml
+++ b/docker/config/config.yaml
@@ -9,12 +9,7 @@ storage:
   cache:
     blobdescriptor: inmemory
   inmemory:
-  # filesystem:
-  #   rootdirectory: /var/lib/registry
-#auth:
-#  silly:
-#    realm: http://localhost:5000/
-#    service: silly-service
+
 http:
   addr: :5000
   headers:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -16,7 +16,6 @@ services:
     restart: always
     volumes:
       - ./config/config.yaml:/etc/docker/registry/config.yml:Z
-      - ./config/tls:/etc/docker/registry/certs:Z
 
   registry-ui:
     image: joxit/docker-registry-ui:latest
@@ -39,11 +38,3 @@ services:
       - TAGLIST_PAGE_SIZE=100
       - REGISTRY_SECURED=false
       - CATALOG_ELEMENTS_LIMIT=1000
-
-  otlp-collector:
-    image: otel/opentelemetry-collector:0.103.0
-    restart: always
-    ports:
-      - 4317:4317
-      - 4318:4318
-      - 55679:55679

--- a/docs/examples/justfile
+++ b/docs/examples/justfile
@@ -1,8 +1,14 @@
 
+# Helper to output github log grouping when run in a github workflow
+_group name:
+    @echo "{{ if env_var_or_default("GITHUB_WORKFLOW", "") != "" { "::group::"+name } else { "" } }}"
+
+_endgroup:
+    @echo "{{ if env_var_or_default("GITHUB_WORKFLOW", "") != "" { "::endgroup::" } else { "" } }}"
 
 # Publish using the `poetry` package manager
 [group("poetry")]
-poetry-publish version username="" token="" repository="https://pyoci.com/ghcr.io/allexveldman/":
+poetry-publish version username="" token="" repository="https://pyoci.com/ghcr.io/allexveldman/": (_group "poetry-publish") && _endgroup
     #!/usr/bin/env bash
     set -exuo pipefail
 
@@ -13,7 +19,7 @@ poetry-publish version username="" token="" repository="https://pyoci.com/ghcr.i
     poetry publish -n -r pyoci -u "{{username}}" -p "{{token}}"
 
 [group("poetry")]
-poetry-install version username="" token="" repository="https://pyoci.com/ghcr.io/allexveldman/":
+poetry-install version username="" token="" repository="https://pyoci.com/ghcr.io/allexveldman/": (_group "poetry-install") && _endgroup
     #!/usr/bin/env bash
     set -exuo pipefail
 
@@ -28,7 +34,7 @@ poetry-install version username="" token="" repository="https://pyoci.com/ghcr.i
     poetry run python -m hello_world
 
 [group("curl")]
-curl-publish version username token repository="http://localhost:8080/ghcr.io/allexveldman/":
+curl-publish version username token repository="http://localhost:8080/ghcr.io/allexveldman/": (_group "curl-publish") && _endgroup
     #!/usr/bin/env bash
     set -exuo pipefail
 
@@ -36,6 +42,7 @@ curl-publish version username token repository="http://localhost:8080/ghcr.io/al
     poetry version {{version}}
     poetry build -f sdist
     curl -v {{repository}} \
+    --fail-with-body \
     -u {{username}}:{{token}} \
     -F ":action=file_upload" \
     -F protocol_version=1 \
@@ -47,17 +54,21 @@ curl-publish version username token repository="http://localhost:8080/ghcr.io/al
     -F content=@dist/hello_world-{{version}}.tar.gz
 
 [group("curl")]
-curl-list username token repository="http://localhost:8080/ghcr.io/allexveldman/":
-    curl -v -u {{username}}:{{token}} {{repository}}hello-world/
+curl-list username token repository="http://localhost:8080/ghcr.io/allexveldman/": (_group "curl-list") && _endgroup
+    curl -v --fail-with-body -u {{username}}:{{token}} {{repository}}hello-world/
 
 [group("curl")]
-curl-list-json username token repository="http://localhost:8080/ghcr.io/allexveldman/":
-    curl -v -u {{username}}:{{token}} {{repository}}hello-world/json
+curl-list-json username token repository="http://localhost:8080/ghcr.io/allexveldman/": (_group "curl-list-json") && _endgroup
+    curl -v --fail-with-body -u {{username}}:{{token}} {{repository}}hello-world/json
 
 [group("curl")]
-curl-download version username token repository="http://localhost:8080/ghcr.io/allexveldman/":
-    curl -vOJ -u {{username}}:{{token}} {{repository}}hello_world/hello_world-{{version}}.tar.gz
+curl-download version username token repository="http://localhost:8080/ghcr.io/allexveldman/": (_group "curl-download") && _endgroup
+    curl -vOJ --fail-with-body -u {{username}}:{{token}} {{repository}}hello_world/hello_world-{{version}}.tar.gz
     rm hello_world-{{version}}.tar.gz
+
+[group("curl")]
+curl-delete version username token repository="http://localhost:8080/ghcr.io/allexveldman/": (_group "curl-delete") && _endgroup
+    curl -v --fail-with-body -u {{username}}:{{token}} -X "DELETE" {{repository}}hello-world/{{version}}
 
 # Undo changes in the examples to the most recent commit
 reset:

--- a/justfile
+++ b/justfile
@@ -13,9 +13,9 @@ refresh-registry:
     docker compose -f docker/docker-compose.yaml up --build --force-recreate --wait pyoci registry
 
 # Run a smoketest on a local pyoci instance and a local OCI registry
-[group("test")]
+[group("ci")]
 test-smoke: refresh-registry
-    @lsof -i -P | grep "5000 (LISTEN)" || { echo "docker registry is not listening on port 5000"; exit 1; }
-    @lsof -i -P | grep "8080 (LISTEN)" || { echo "pyoci is not listening on port 8080"; exit 1; }
     just examples::poetry-publish "0.1.0+1234" "foo" "bar" "http://localhost:8080/http%3A%2F%2Fregistry%3A5000/pyoci/"
     just examples::poetry-install "0.1.0+1234" "foo" "bar" "http://localhost:8080/http%3A%2F%2Fregistry%3A5000/pyoci/"
+    just examples::curl-list-json "foo" "bar" "http://localhost:8080/http%3A%2F%2Fregistry%3A5000/pyoci/"
+    just examples::curl-delete "0.1.0+1234" "foo" "bar" "http://localhost:8080/http%3A%2F%2Fregistry%3A5000/pyoci/"

--- a/src/package.rs
+++ b/src/package.rs
@@ -8,6 +8,7 @@ use crate::pyoci::PyOciError;
 pub trait FileState {}
 
 pub struct WithFile;
+#[derive(Clone)]
 pub struct WithoutFile;
 
 impl FileState for WithFile {}
@@ -75,7 +76,7 @@ pub fn from_filename<'a>(
     })
 }
 
-impl<T: FileState> Package<'_, T> {
+impl<'a, T: FileState> Package<'a, T> {
     /// Add/replace the version and architecture of the package for OCI provided values
     ///
     /// Replaces '-' by '+' to get back to the python definition of the version
@@ -83,7 +84,7 @@ impl<T: FileState> Package<'_, T> {
     /// <reference> as a tag MUST be at most 128 characters in length and MUST match the following regular expression:
     /// [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}
     /// <https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests>
-    pub fn with_oci_file(&self, tag: &str, arch: &str) -> Package<WithFile> {
+    pub fn with_oci_file(&self, tag: &str, arch: &str) -> Package<'a, WithFile> {
         Package {
             registry: self.registry,
             namespace: self.namespace,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -96,6 +96,10 @@ impl HttpTransport {
     pub fn head(&self, url: url::Url) -> reqwest::RequestBuilder {
         self.client.head(url)
     }
+    /// Create a new DELETE request
+    pub fn delete(&self, url: url::Url) -> reqwest::RequestBuilder {
+        self.client.delete(url)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add support for deleting a package version.

- `ghcr.io` does not support deleting using the OCI distribution spec.
- Runs the smoke-test as part of the publish workflow