### PR TITLE
feat(auth): Include `scope` in the token exchange

### DIFF
--- a/src/service/log.rs
+++ b/src/service/log.rs
@@ -53,6 +53,7 @@ where
     }
 
     fn call(&mut self, request: reqwest::Request) -> Self::Future {
+        tracing::debug!("{:?}", request);
         LogFuture {
             method: request.method().to_string(),
             url: request.url().to_string(),
@@ -82,6 +83,7 @@ where
         let result = ready!(this.inner_fut.poll(cx));
         match &result {
             Ok(response) => {
+                tracing::debug!("{:?}", response);
                 let status: u16 = response.status().into();
                 tracing::info!(
                     method = this.method,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -67,7 +67,6 @@ impl HttpTransport {
     /// this session.
     pub async fn send(&mut self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
         let request = request.build()?;
-        tracing::debug!("Request: {:#?}", request);
 
         let mut service = ServiceBuilder::new()
             .layer(self.auth_layer.clone())
@@ -76,7 +75,6 @@ impl HttpTransport {
         poll_fn(|ctx| service.poll_ready(ctx)).await?;
         let response = service.call(request).await?;
 
-        tracing::debug!("Response Headers: {:#?}", response.headers());
         Ok(response)
     }
 


### PR DESCRIPTION
The `scope` parameter(s) during token exchange are now included. This means the returned token will have an explicit scope.

It also means we need to re-authenticate if a subsequent request requires a different scope.
For example, during publish we first pull the IndexManifest, then push blobs and manifests.

`ghcr.io` does not care about the scope, just the
originally provided token.
Azure container registry does care about the scope and as such requires this change.