### PR TITLE
ci(release): Rework the release workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,12 +1,36 @@
 name: Publish
 
 on:
+  # Tests docker build without pushing
   push:
-    tags:
-      - '*'
     branches:
       - main
   pull_request:
+
+  # Manually, or from another workflow, trigger build of a new version
+  workflow_call:
+    inputs:
+      version:
+        description: 'SemVer version to create'
+        required: true
+        type: string
+      publish:
+        description: 'Publish the new version'
+        required: true
+        type: boolean
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Manually create a new SemVer version, will not create a release or tag, use with caution"
+        required: true
+        type: string
+      publish:
+        description: 'Publish the new version'
+        required: false
+        type: boolean
+        default: false
+
 
 concurrency:
   # Cancel existing runs when pushing to the same branch of a PR
@@ -39,8 +63,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,value=${{ inputs.version }},pattern={{version}}
+            type=semver,value=${{ inputs.version }},pattern={{major}}.{{minor}}
             type=sha
 
       - name: Set up Docker Buildx
@@ -61,7 +85,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/allexveldman/pyoci:latest
           cache-to: type=inline
           load: true
-          push: ${{ github.ref_type == 'tag' }}
+          push: ${{ inputs.publish || false }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -74,16 +98,3 @@ jobs:
         run: just test-smoke
       - run: docker compose logs pyoci
         working-directory: ./docker
-
-  deploy:
-    name: Deploy
-    needs: [build]
-    if: ${{ github.ref_type == 'tag' }}
-    uses: ./.github/workflows/deploy.yaml
-    with:
-      version: ${{ needs.build.outputs.version }}
-    secrets: inherit
-    permissions:
-      contents: read
-      id-token: write
-      packages: write

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,4 +1,4 @@
-name: Release Please
+name: Release
 
 on:
   push:
@@ -20,8 +20,37 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    outputs:
+      version: ${{ steps.release-please.outputs.major }}.${{ steps.release-please.outputs.minor }}.${{ steps.release-please.outputs.patch }}
+      publish: ${{ steps.release-please.outputs.release_created }}
+
     steps:
       - uses: googleapis/release-please-action@v4
         id: release-please
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish
+    needs: [release]
+    if: needs.release.outputs.publish
+    uses: ./.github/workflows/publish.yaml
+    with:
+      version: ${{ needs.release.outputs.version }}
+      publish: ${{ needs.release.outputs.publish }}
+    permissions:
+      contents: read
+      packages: write
+
+  deploy:
+    name: Deploy
+    needs: [release, publish]
+    if: needs.release.outputs.publish
+    uses: ./.github/workflows/deploy.yaml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+      packages: write


### PR DESCRIPTION
The Docker build and publish are now called directly from the release-please workflow on push to `main` instead of relying on the creation of a tag when the github release is created.

The main benefit is that I don't need a PAT to trigger the workflows.