### PR TITLE
fix(auth): Log a warning when no auth is provided

### DIFF
--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Context, Error, Result};
 use base16ct::lower::encode_string as hex_encode;
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
+use http::HeaderValue;
 use http::StatusCode;
 use oci_spec::{
     distribution::TagList,
@@ -160,7 +161,7 @@ pub struct PyOci {
 
 impl PyOci {
     /// Create a new Client
-    pub fn new(registry: Url, auth: Option<String>) -> Result<Self> {
+    pub fn new(registry: Url, auth: Option<HeaderValue>) -> Result<Self> {
         Ok(PyOci {
             registry,
             transport: HttpTransport::new(auth)?,

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -25,16 +25,7 @@ pub struct AuthLayer {
 }
 
 impl AuthLayer {
-    pub fn new(basic_token: Option<String>) -> Result<Self> {
-        let basic_token = match basic_token {
-            None => None,
-            Some(token) => {
-                let mut token = http::HeaderValue::try_from(token)?;
-                token.set_sensitive(true);
-                Some(token)
-            }
-        };
-
+    pub fn new(basic_token: Option<HeaderValue>) -> Result<Self> {
         Ok(Self {
             basic: basic_token,
             bearer: Arc::new(RwLock::new(None)),
@@ -441,7 +432,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some("Basic mybasicauth".into())).unwrap())
+            .layer(
+                AuthLayer::new(Some(HeaderValue::try_from("Basic mybasicauth").unwrap())).unwrap(),
+            )
             .service(Client::default());
         let request = reqwest::Request::new(
             http::Method::GET,
@@ -494,7 +487,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some("Basic mybasicauth".into())).unwrap())
+            .layer(
+                AuthLayer::new(Some(HeaderValue::try_from("Basic mybasicauth").unwrap())).unwrap(),
+            )
             .service(Client::default());
         let request = reqwest::Request::new(
             http::Method::GET,
@@ -585,7 +580,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some("Basic mybasicauth".into())).unwrap())
+            .layer(
+                AuthLayer::new(Some(HeaderValue::try_from("Basic mybasicauth").unwrap())).unwrap(),
+            )
             .service(Client::default());
 
         // First request
@@ -631,7 +628,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some("Basic mybasicauth".into())).unwrap())
+            .layer(
+                AuthLayer::new(Some(HeaderValue::try_from("Basic mybasicauth").unwrap())).unwrap(),
+            )
             .service(Client::default());
 
         // Construct a request that can't be cloned
@@ -701,7 +700,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some("Basic mybasictoken".into())).unwrap())
+            .layer(
+                AuthLayer::new(Some(HeaderValue::try_from("Basic mybasicauth").unwrap())).unwrap(),
+            )
             .service(Client::default());
 
         let request = reqwest::Request::new(
@@ -745,7 +746,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some("Basic mybasictoken".into())).unwrap())
+            .layer(
+                AuthLayer::new(Some(HeaderValue::try_from("Basic mybasicauth").unwrap())).unwrap(),
+            )
             .service(Client::default());
 
         let request = reqwest::Request::new(
@@ -799,7 +802,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some("Basic mybasictoken".into())).unwrap())
+            .layer(
+                AuthLayer::new(Some(HeaderValue::try_from("Basic mybasictoken").unwrap())).unwrap(),
+            )
             .service(Client::default());
 
         let request = reqwest::Request::new(

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use http::HeaderValue;
 use std::boxed::Box;
 use std::future::poll_fn;
 use std::future::Future;
@@ -52,7 +53,7 @@ impl HttpTransport {
     ///
     /// auth: Basic auth string
     ///       Will be swapped for a Bearer token if needed
-    pub fn new(auth: Option<String>) -> Result<Self> {
+    pub fn new(auth: Option<HeaderValue>) -> Result<Self> {
         let client = reqwest::Client::builder().user_agent(USER_AGENT);
         Ok(Self {
             client: client.build().unwrap(),
@@ -166,7 +167,8 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string())).unwrap();
+        let mut transport =
+            HttpTransport::new(Some(HeaderValue::try_from("Basic mybasicauth").unwrap())).unwrap();
         let request = transport.get(Url::parse(&format!("{url}/foobar")).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -222,7 +224,8 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string())).unwrap();
+        let mut transport =
+            HttpTransport::new(Some(HeaderValue::try_from("Basic mybasicauth").unwrap())).unwrap();
         // clone the transport to check if they share the bearer token state
         let mut transport2 = transport.clone();
 
@@ -295,7 +298,8 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string())).unwrap();
+        let mut transport =
+            HttpTransport::new(Some(HeaderValue::try_from("Basic mybasicauth").unwrap())).unwrap();
         let request = transport.get(Url::parse(&format!("{url}/foobar")).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -341,7 +345,8 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(Some("Basic mybasicauth".to_string())).unwrap();
+        let mut transport =
+            HttpTransport::new(Some(HeaderValue::try_from("Basic mybasicauth").unwrap())).unwrap();
         let request = transport.get(Url::parse(&format!("{url}/foobar")).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {


### PR DESCRIPTION
The Authorization HeaderValue is no longer dumped to String and then parsed to HeaderValue again, instead the original HeaderValue is cloned and passed to the auth layer.