### PR TITLE
chore: Include creation date in image index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,10 +1859,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1870,6 +1872,16 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tower = { version = "0.5.1", features = ["util"] }
 async-trait = "0.1.83"
 pin-project = "1.1.7"
 futures = "0.3.31"
-time = "0.3.36"
+time = { version = "0.3.36", features = ["formatting"] }
 axum = { version = "0.7.9", default-features = false, features = ["multipart","macros", "tokio", "http1", "json"] }
 tokio = { version = "1.41.1", features = ["macros", "rt-multi-thread", "signal", "time"] }
 tokio-util = "0.7.12"

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,7 +39,6 @@ where
 }
 /// Request Router
 pub fn router() -> Router {
-    // TODO: Validate HOST header against a list of allowed hosts
     Router::new()
         .fallback(
             get(|| async { StatusCode::NOT_FOUND })
@@ -714,6 +713,9 @@ mod tests {
         let url = server.url();
         let encoded_url = urlencoding::encode(&url).into_owned();
 
+        // Set timestamp to fixed time
+        crate::mocks::set_timestamp(1732134216);
+
         let mocks = vec![
             // Mock the server, in order of expected requests
             // IndexManifest does not yet exist
@@ -776,7 +778,7 @@ mod tests {
             server
                 .mock("PUT", "/v2/mockserver/foobar/manifests/1.0.0")
                 .match_header("Content-Type", "application/vnd.oci.image.index.v1+json")
-                .match_body(r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","artifactType":"application/pyoci.package.v1","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:7ffd96d9eab411893eeacfa906e30956290a07b0141d7c1dd54c9fd5c7c48cf5","size":422,"platform":{"architecture":".tar.gz","os":"any"}}]}"#)
+                .match_body(r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","artifactType":"application/pyoci.package.v1","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:7ffd96d9eab411893eeacfa906e30956290a07b0141d7c1dd54c9fd5c7c48cf5","size":422,"platform":{"architecture":".tar.gz","os":"any"}}],"annotations":{"org.opencontainers.image.created":"2024-11-20T20:23:36Z"}}"#)
                 .with_status(201) // CREATED
                 .create_async()
                 .await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,10 @@ mod transport;
 // Services
 mod service;
 
+// Test mocks
+#[cfg(test)]
+mod mocks;
+
 pub use pyoci::PyOci;
 use tokio::task::JoinHandle;
 

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -1,0 +1,20 @@
+use std::cell::Cell;
+
+thread_local! {
+    static TIMESTAMP: Cell<i64> = const { Cell::new(0) };
+}
+/// Mock of OffsetDateTime::now_utc
+/// Use set_timestamp to manipulate now_utc
+pub struct OffsetDateTime {}
+
+impl OffsetDateTime {
+    pub fn now_utc() -> time::OffsetDateTime {
+        TIMESTAMP
+            .with(|timestamp| time::OffsetDateTime::from_unix_timestamp(timestamp.get()))
+            .expect("a valid timestamp")
+    }
+}
+
+pub fn set_timestamp(timestamp: i64) {
+    TIMESTAMP.with(|ts| ts.set(timestamp));
+}

--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -15,8 +15,15 @@ use oci_spec::{
 use reqwest::Response;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::str::FromStr;
+use time::format_description::well_known::Rfc3339;
 use url::Url;
+
+#[cfg(test)]
+use crate::mocks::OffsetDateTime;
+#[cfg(not(test))]
+use time::OffsetDateTime;
 
 use crate::package::{Package, WithFile, WithoutFile};
 use crate::transport::HttpTransport;
@@ -378,6 +385,10 @@ impl PyOci {
                 .media_type("application/vnd.oci.image.index.v1+json")
                 .artifact_type(ARTIFACT_TYPE)
                 .manifests(vec![manifest.descriptor()])
+                .annotations(HashMap::from([(
+                    "org.opencontainers.image.created".to_string(),
+                    OffsetDateTime::now_utc().format(&Rfc3339)?,
+                )]))
                 .build()
                 .expect("valid ImageIndex"),
             // Existing index found, check artifact type


### PR DESCRIPTION
Add the `org.opencontainers.image.created` annotation to newly created Index manifests.

The annotation is not (yet) used on the python side.