### PR TITLE
chore: Add created timestamp to manifest

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -15,14 +15,20 @@ This allows multiple build artifacts to be published to the same package version
   "manifests": [
     {
       "mediaType": "application/vnd.oci.image.manifest.v1+json",
-      "digest": "sha256:7ffd96d9eab411893eeacfa906e30956290a07b0141d7c1dd54c9fd5c7c48cf5",
-      "size": 422,
+      "digest": "sha256:e281659053054737342fd0c74a7605c4678c227db1e073260b44f845dfdf535a",
+      "size": 496,
       "platform": {
         "architecture": ".tar.gz",
         "os": "any"
+      },
+      "annotations": {
+        "org.opencontainers.image.created":"2024-11-20T20:23:36Z"
       }
     }
-  ]
+  ],
+  "annotations": {
+    "org.opencontainers.image.created":"2024-11-20T20:23:36Z"
+  }
 }
 ```
 
@@ -44,7 +50,10 @@ This allows multiple build artifacts to be published to the same package version
       "digest": "sha256:b7513fb69106a855b69153582dec476677b3c79f4a13cfee6fb7a356cfa754c0",
       "size": 22
     }
-  ]
+  ],
+  "annotations": {
+    "org.opencontainers.image.created":"2024-11-20T20:23:36Z"
+  }
 }
 ```
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -804,9 +804,9 @@ mod tests {
                 .await,
             // PUT request to create Manifest
             server
-                .mock("PUT", "/v2/mockserver/foobar/manifests/sha256:7ffd96d9eab411893eeacfa906e30956290a07b0141d7c1dd54c9fd5c7c48cf5")
+                .mock("PUT", "/v2/mockserver/foobar/manifests/sha256:e281659053054737342fd0c74a7605c4678c227db1e073260b44f845dfdf535a")
                 .match_header("Content-Type", "application/vnd.oci.image.manifest.v1+json")
-                .match_body(r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":"application/pyoci.package.v1","config":{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2},"layers":[{"mediaType":"application/pyoci.package.v1","digest":"sha256:b7513fb69106a855b69153582dec476677b3c79f4a13cfee6fb7a356cfa754c0","size":22}]}"#)
+                .match_body(r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":"application/pyoci.package.v1","config":{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2},"layers":[{"mediaType":"application/pyoci.package.v1","digest":"sha256:b7513fb69106a855b69153582dec476677b3c79f4a13cfee6fb7a356cfa754c0","size":22}],"annotations":{"org.opencontainers.image.created":"2024-11-20T20:23:36Z"}}"#)
                 .with_status(201) // CREATED
                 .create_async()
                 .await,
@@ -814,7 +814,7 @@ mod tests {
             server
                 .mock("PUT", "/v2/mockserver/foobar/manifests/1.0.0")
                 .match_header("Content-Type", "application/vnd.oci.image.index.v1+json")
-                .match_body(r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","artifactType":"application/pyoci.package.v1","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:7ffd96d9eab411893eeacfa906e30956290a07b0141d7c1dd54c9fd5c7c48cf5","size":422,"platform":{"architecture":".tar.gz","os":"any"}}],"annotations":{"org.opencontainers.image.created":"2024-11-20T20:23:36Z"}}"#)
+                .match_body(r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","artifactType":"application/pyoci.package.v1","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:e281659053054737342fd0c74a7605c4678c227db1e073260b44f845dfdf535a","size":496,"annotations":{"org.opencontainers.image.created":"2024-11-20T20:23:36Z"},"platform":{"architecture":".tar.gz","os":"any"}}],"annotations":{"org.opencontainers.image.created":"2024-11-20T20:23:36Z"}}"#)
                 .with_status(201) // CREATED
                 .create_async()
                 .await,


### PR DESCRIPTION
Includes the `org.opencontainers.image.created` annotations for created Manifests and it's Descriptor.

This allows a distinction between creation of the first file of a version and subsequent uploads to the same version.