### PR TITLE
feat: Allow hosting PyOCI on a subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install --index-url="https://$GITHUB_USER:$GITHUB_TOKEN@pyoci.com/ghcr.io/al
 For more examples, including how to publish a package, see the [examples](/docs/examples).
 
 ## Host your own
-If you don't want or can't use https://pyoci.com, you can host your own using the docker container.
+If you don't want, or can't, use https://pyoci.com, you can host your own using the docker container.
 
 `docker run ghcr.io/allexveldman/pyoci:latest`
 
@@ -58,6 +58,7 @@ PyOCI is expected to run behind a reverse proxy that handles TLS termination, or
 
 ### Environment variables
 - `PORT`: port to listen on, defaults to `8080`.
+- `PYOCI_PATH`: Host PyOCI on a subpath, for example: `PYOCI_PATH="/acme-corp"`.
 - `OTLP_ENDPOINT`: If set, forward logs, traces, and metrics to this OTLP collector endpoint every 30s.
 - `OTLP_AUTH`: Full Authorization header value to use when sending OTLP requests.
 - `RUST_LOG`: Log filter, defaults to `info`.

--- a/docs/examples/justfile
+++ b/docs/examples/justfile
@@ -25,6 +25,9 @@ poetry-install version username="" token="" repository="https://pyoci.com/ghcr.i
 
     cd ./poetry/install
 
+    # Ensure we start with a clean venv
+    poetry env remove --all
+
     # Setup the registry source credentials
     poetry source add --priority=explicit pyoci "{{repository}}"
     export POETRY_HTTP_BASIC_PYOCI_USERNAME={{username}}

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -4,5 +4,6 @@ use askama::Template;
 #[derive(Template)]
 #[template(path = "list-package.html")]
 pub struct ListPackageTemplate<'a> {
+    pub subpath: &'a str,
     pub files: Vec<Package<'a, WithFile>>,
 }

--- a/templates/list-package.html
+++ b/templates/list-package.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 {%- for file in files %}
-    <a href="{{ file.py_uri() }}">{{ file.filename() }}</a>
+    <a href="{{ subpath }}{{ file.py_uri() }}">{{ file.filename() }}</a>
 {%- endfor %}
 </body>
 </html>


### PR DESCRIPTION
When environment variable `PYOCI_PATH` is set, all URLs are resolved as a subpath of `PYOCI_PATH`.
This is also reflected in the links provided by `list_packages`.

closes: #141