### PR TITLE
feat: Allow configuring the max body size

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ PyOCI is expected to run behind a reverse proxy that handles TLS termination, or
 ### Environment variables
 - `PORT`: port to listen on, defaults to `8080`.
 - `PYOCI_PATH`: Host PyOCI on a subpath, for example: `PYOCI_PATH="/acme-corp"`.
+- `PYOCI_MAX_BODY`: Limit the maximum accepted body size in bytes when publishing packages, defaults to 50MB.
 - `OTLP_ENDPOINT`: If set, forward logs, traces, and metrics to this OTLP collector endpoint every 30s.
 - `OTLP_AUTH`: Full Authorization header value to use when sending OTLP requests.
 - `RUST_LOG`: Log filter, defaults to `info`.

--- a/docs/examples/justfile
+++ b/docs/examples/justfile
@@ -8,7 +8,7 @@ _endgroup:
 
 # Publish using the `poetry` package manager
 [group("poetry")]
-poetry-publish version username token repository="https://localhost:8080/ghcr.io/allexveldman/": (_group "poetry-publish") && _endgroup
+poetry-publish version username token repository="http://localhost:8080/ghcr.io/allexveldman/": (_group "poetry-publish") && _endgroup
     #!/usr/bin/env bash
     set -exuo pipefail
 
@@ -19,7 +19,7 @@ poetry-publish version username token repository="https://localhost:8080/ghcr.io
     poetry publish -n -r pyoci -u "{{username}}" -p "{{token}}"
 
 [group("poetry")]
-poetry-install version username token repository="https://localhost:8080/ghcr.io/allexveldman/": (_group "poetry-install") && _endgroup
+poetry-install version username token repository="http://localhost:8080/ghcr.io/allexveldman/": (_group "poetry-install") && _endgroup
     #!/usr/bin/env bash
     set -exuo pipefail
 

--- a/docs/examples/poetry/publish/poetry.toml
+++ b/docs/examples/poetry/publish/poetry.toml
@@ -1,2 +1,2 @@
 [repositories.pyoci]
-url = "https://pyoci.com/ghcr.io/allexveldman/"
+url = "http://localhost:8080/ghcr.io/allexveldman/"

--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Error, Result};
+use axum::response::IntoResponse;
 use base16ct::lower::encode_string as hex_encode;
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
@@ -136,6 +137,12 @@ impl std::error::Error for PyOciError {}
 impl std::fmt::Display for PyOciError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}: {}", self.status, self.message)
+    }
+}
+
+impl IntoResponse for PyOciError {
+    fn into_response(self) -> axum::response::Response {
+        (self.status, self.message).into_response()
     }
 }
 


### PR DESCRIPTION
The body size limit can now be set using `PYOCI_MAX_BODY`. Defaults to 50MB.

fix: Return HTTP 413 Payload Too Large instead of 500