### PR TITLE
feat: Allow setting labels on the OCI image

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Set by Azure Container App, can change if I every decide to move host:
 - `CONTAINER_APP_REVISION` -> `k8s.pod.name`
 - `CONTAINER_APP_REPLICA_NAME` -> `k8s.replicaset.name`
 
+## Add Labels to your package
+Labels can be added to your package by including them as a `PyOCI :: Label :: <Key> :: <Value>` [classifier](https://packaging.python.org/en/latest/specifications/core-metadata/#classifier-multiple-use) of the package.
+If the classifiers are found in the package upload request, the key-value pairs will be added as [annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md) (aka labels in docker terms) to the OCI image.
+
+Note that these classifiers are case-sensitive and [non-standard](https://pypi.org/classifiers/).
 
 ## Authentication
 Pip's [Basic authentication](https://pip.pypa.io/en/stable/topics/authentication/#basic-http-authentication)

--- a/docs/examples/poetry/publish/pyproject.toml
+++ b/docs/examples/poetry/publish/pyproject.toml
@@ -4,6 +4,11 @@ version = "0.0.1"
 description = "Example project for PyOCI with poetry"
 authors = ["Allex Veldman <allexveldman@gmail.com>"]
 
+classifiers = [
+    "PyOCI :: Label :: org.opencontainers.image.url :: https://github.com/allexveldman/pyoci",
+    "PyOCI :: Label :: org.opencontainers.image.description :: Published using PyOCI as part of the examples."
+]
+
 [tool.poetry.dependencies]
 python = "^3.8"
 

--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -360,15 +360,17 @@ impl PyOci {
         &mut self,
         package: &Package<'_, WithFile>,
         file: Vec<u8>,
+        mut annotations: HashMap<String, String>,
     ) -> Result<()> {
         let name = package.oci_name();
         let tag = package.oci_tag();
 
         let layer = Blob::new(file, ARTIFACT_TYPE);
-        let annotations = HashMap::from([(
+        annotations.insert(
             "org.opencontainers.image.created".to_string(),
             OffsetDateTime::now_utc().format(&Rfc3339)?,
-        )]);
+        );
+
         // Build the Manifest
         let config = empty_config();
         let manifest = ImageManifestBuilder::default()


### PR DESCRIPTION
The OCI image spec allows for "annotations" (aka labels in docker terms) to be added to the image index and manifests.

Python allows adding "classifiers" to python package metadata.

If a packages defines a classifier in the format `PyOCI :: Label :: Key :: Value`, a label `Key=Value` will be added to the created image.

closes: #158 