### PR TITLE
refactor: Refactor of the publish path and HttpTransport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1204,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1291,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "pin-project",
+ "pretty_assertions",
  "prost",
  "reqwest",
  "serde",
@@ -2464,6 +2481,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,4 @@ test-case = "3.3.1"
 tokio = { version = "1.43.0", features = ["test-util"]}
 bytes = "1.9.0"
 reqwest = { version = "0.12.12", default-features = false, features = ["stream"] }
+pretty_assertions = "1.4.1"

--- a/docs/design.md
+++ b/docs/design.md
@@ -7,6 +7,10 @@ Packages published through PyOCI use the `application/pyoci.package.v1` [artifac
 The image index gets tagged with the package version.
 This allows multiple build artifacts to be published to the same package version.
 
+`com.pyoci.sha256_digest` is added as an annotation in the `ImageIndex.manifests[]`
+containing the digest of the package blob.
+This is so we don't need to pull the manifest itself to get the digest of the package.
+
 ```json
 {
   "schemaVersion": 2,
@@ -22,7 +26,8 @@ This allows multiple build artifacts to be published to the same package version
         "os": "any"
       },
       "annotations": {
-        "org.opencontainers.image.created":"2024-11-20T20:23:36Z"
+        "org.opencontainers.image.created":"2024-11-20T20:23:36Z",
+        "com.pyoci.sha256_digest": "b7513fb69106a855b69153582dec476677b3c79f4a13cfee6fb7a356cfa754c0"
       }
     }
   ],
@@ -33,6 +38,11 @@ This allows multiple build artifacts to be published to the same package version
 ```
 
 ## Image Manifest
+
+When a package is published with `PyOci :: Label :: <key> :: <value>` classifiers,
+the key/value pair will be added to the ImageManifest annotations.
+
+'org.opencontainers.image.created' will always be added.
 
 ```json
 {
@@ -52,6 +62,8 @@ This allows multiple build artifacts to be published to the same package version
     }
   ],
   "annotations": {
+    "org.opencontainers.image.description": "Published using PyOCI as part of the examples.",
+    "org.opencontainers.image.url": "https://github.com/allexveldman/pyoci",
     "org.opencontainers.image.created":"2024-11-20T20:23:36Z"
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ mod service;
 #[cfg(test)]
 mod mocks;
 
-pub use pyoci::PyOci;
+use pyoci::PyOci;
 use tokio::task::JoinHandle;
 
 use std::collections::HashMap;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,9 +1,9 @@
-use crate::package::{Package, WithFile};
+use crate::package::{Package, WithFileName};
 use askama::Template;
 
 #[derive(Template)]
 #[template(path = "list-package.html")]
 pub struct ListPackageTemplate<'a> {
     pub subpath: &'a str,
-    pub files: Vec<Package<'a, WithFile>>,
+    pub files: Vec<Package<'a, WithFileName>>,
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -11,6 +11,39 @@ use crate::service::AuthLayer;
 use crate::service::RequestLogLayer;
 use crate::USER_AGENT;
 
+pub trait Transport {
+    /// Send a request
+    ///
+    /// When authentication is required, this method will automatically authenticate
+    /// using the provided Basic auth string and caches the Bearer token for future requests within
+    /// this session.
+    async fn send(&mut self, request: reqwest::RequestBuilder) -> Result<reqwest::Response>;
+
+    /// Return the underlying client
+    fn client(&self) -> &reqwest::Client;
+
+    /// Create a new GET request
+    fn get(&self, url: url::Url) -> reqwest::RequestBuilder {
+        self.client().get(url)
+    }
+    /// Create a new POST request
+    fn post(&self, url: url::Url) -> reqwest::RequestBuilder {
+        self.client().post(url)
+    }
+    /// Create a new PUT request
+    fn put(&self, url: url::Url) -> reqwest::RequestBuilder {
+        self.client().put(url)
+    }
+    /// Create a new HEAD request
+    fn head(&self, url: url::Url) -> reqwest::RequestBuilder {
+        self.client().head(url)
+    }
+    /// Create a new DELETE request
+    fn delete(&self, url: url::Url) -> reqwest::RequestBuilder {
+        self.client().delete(url)
+    }
+}
+
 /// HTTP Transport
 ///
 /// This struct is responsible for sending HTTP requests to the upstream OCI registry.
@@ -60,13 +93,15 @@ impl HttpTransport {
             auth_layer: AuthLayer::new(auth)?,
         })
     }
+}
 
+impl Transport for HttpTransport {
     /// Send a request
     ///
     /// When authentication is required, this method will automatically authenticate
     /// using the provided Basic auth string and caches the Bearer token for future requests within
     /// this session.
-    pub async fn send(&mut self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
+    async fn send(&mut self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
         let request = request.build()?;
 
         let mut service = ServiceBuilder::new()
@@ -79,25 +114,8 @@ impl HttpTransport {
         Ok(response)
     }
 
-    /// Create a new GET request
-    pub fn get(&self, url: url::Url) -> reqwest::RequestBuilder {
-        self.client.get(url)
-    }
-    /// Create a new POST request
-    pub fn post(&self, url: url::Url) -> reqwest::RequestBuilder {
-        self.client.post(url)
-    }
-    /// Create a new PUT request
-    pub fn put(&self, url: url::Url) -> reqwest::RequestBuilder {
-        self.client.put(url)
-    }
-    /// Create a new HEAD request
-    pub fn head(&self, url: url::Url) -> reqwest::RequestBuilder {
-        self.client.head(url)
-    }
-    /// Create a new DELETE request
-    pub fn delete(&self, url: url::Url) -> reqwest::RequestBuilder {
-        self.client.delete(url)
+    fn client(&self) -> &reqwest::Client {
+        &self.client
     }
 }
 


### PR DESCRIPTION
To improve the testability of publishing a package, `PyOci.publish_package()` is split into multiple methods.

Tests for the refactored parts were moved/restructured so it is no longer needed to go through the entire request flow for every test (including mockito).

A new Trait `Transport` is introduced and `PyOci` is generic over `Transport`.
This allows swapping the `HttpTransport` in unittests in the future, removing the need to mockito in a lot of cases.

Annotations have been structured a bit more.
- ImageIndex annotations will only include it's creation timestamp
- ImageIndex.manifests[] annotations will include package metadata we might need when listing/searching packages
- ImageManifest annotations will contain user-defined labels through `PyOci :: Label :: ` classifiers.

The `com.pyoci.sha256_digest` annotation is added containing the SHA256 digest of the package blob.
This is a first step to make #160 work in an effective manner.

feat: SHA256 digest of the provided content is checked against the provided `sha256_digest` in the request.