### PR TITLE
feat: Add the package digest to `list_package`

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -72,9 +72,9 @@ the key/value pair will be added to the ImageManifest annotations.
 # References
 
 ### PyPi
-- Simple API: https://peps.python.org/pep-0503/
-- Simple JSON extention: https://peps.python.org/pep-0691/#content-types
-- JSON API: https://warehouse.pypa.io/api-reference/json.html#
+- Simple API PEP: https://peps.python.org/pep-0503/
+- Simple JSON extention PEP: https://peps.python.org/pep-0691/#content-types
+- API definitions: https://docs.pypi.org/api/
 
 ### Python packaging
 - Name normalization: https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization

--- a/src/app.rs
+++ b/src/app.rs
@@ -342,8 +342,13 @@ impl UploadForm {
                     if let Some(label) = classifier.strip_prefix("PyOCI :: Label :: ") {
                         if let [key, value] = label.splitn(2, " :: ").collect::<Vec<_>>()[..] {
                             labels.insert(key.to_string(), value.to_string());
-                        };
-                    }
+                            debug!("Found label '{key}={value}'");
+                        } else {
+                            debug!("Invalid PyOci label '{label}'");
+                        }
+                    } else {
+                        debug!("Discarding field 'classifiers': {classifier}");
+                    };
                 }
                 "sha256_digest" => sha256 = Some(field.text().await?),
                 name => debug!("Discarding field '{name}': {}", field.text().await?),


### PR DESCRIPTION
The (html) index of package files now contains the SHA256 digest of the package.

closes: #160