### PR TITLE
chore: Switch console log to a more compact format

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,9 @@ fn setup_tracing(
     cancel_token: CancellationToken,
 ) -> (impl Subscriber, Option<JoinHandle<()>>) {
     // Setup tracing
-    let fmt_layer = tracing_subscriber::fmt::layer();
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_target(false)
+        .compact();
 
     let el_reg = tracing_subscriber::registry()
         .with(EnvFilter::new(&environ.rust_log))


### PR DESCRIPTION
This removes the default `span1{field=foo}:span2{field2=bar}:` prefix from the console logs, instead adding the span fields as logfmt compatible fields.

It also drops the target, in most cases `pyoci::service::log:`, from the message.

before:
```
2025-03-03T08:30:53.609911Z  INFO fetch{otel.path="/ghcr.io/allexveldman/hello-world/" otel.method="GET" otel.span_kind="server"}:list_package:pull_manifest{otel.name="allexveldman/hello_world" otel.reference="0.0.1-example.1.poetry.87e2b29"}: pyoci::service::log: method="GET" type="subrequest" status=200 url="https://ghcr.io/v2/allexveldman/hello_world/manifests/0.0.1-example.1.poetry.87e2b29"
```

after:
```
2025-03-03T08:33:04.075313Z  INFO fetch:list_package:pull_manifest: method="GET" type="subrequest" status=200 url="https://ghcr.io/v2/allexveldman/hello_world/manifests/0.0.1-example.1.poetry.2eaa6ad" otel.path="/ghcr.io/allexveldman/hello-world/" otel.method="GET" otel.span_kind="server" otel.name="allexveldman/hello_world" otel.reference="0.0.1-example.1.poetry.2eaa6ad"

```

Note that this only affects the console logs, the OTLP log exporter stays the same.