### PR TITLE
chore(release): Give dependency updates their own section in changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "deps"
     groups:
       opentelemetry:
-        patterns: 
+        patterns:
         - "opentelemetry*"

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -29,4 +29,5 @@ jobs:
             test
             build
             ci
+            deps
           requireScope: false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -55,6 +55,10 @@
     {
       "type": "ci",
       "section": "Continuous Integration"
+    },
+    {
+      "type": "deps",
+      "section": "Dependency Updates"
     }
   ]
 }


### PR DESCRIPTION
Dependabot updates will now be prefixed with `deps:`. `deps` commits will be placed in the "Dependency Updates" section of the changelog.