### PR TITLE
refactor: Consolidate unix timestamp nano into the `time` module

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -10,6 +10,16 @@ pub use mocks::now_utc;
 #[cfg(test)]
 pub use mocks::set_timestamp;
 
+// Get the unix time in nanoseconds
+// u64 is good until the year 2554.
+// if you crash here this project has exceeded my wildest expectations, congratulations to me!
+pub fn time_unix_ns() -> u64 {
+    now_utc()
+        .unix_timestamp_nanos()
+        .try_into()
+        .expect("Could not fit the current unix timestamp into a u64")
+}
+
 #[cfg(test)]
 mod mocks {
     use std::cell::Cell;


### PR DESCRIPTION
Getting the current utc unix timestamp in nano seconds is done through `time::time_unix_ns()`.
This method assumes this project does not survive until the year 2554 so we can skip error handling in the i128 -> u64 conversion, simplifying all use of the timestamp.