### PR TITLE
refactor(otlp): Remove `opentelemetry_sdk` and `opentelemetry` deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.0",
+ "rand 0.9.1",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1234,8 +1234,8 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2288c0e17cc8d342c712bb43a257a80ebffce59cdb33d5000d8348f3ec02528b"
 dependencies = [
- "zerocopy 0.7.35",
- "zerocopy-derive 0.7.35",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -1323,12 +1323,11 @@ dependencies = [
  "indoc",
  "mockito",
  "oci-spec",
- "opentelemetry",
  "opentelemetry-proto",
- "opentelemetry_sdk",
  "pin-project",
  "pretty_assertions",
  "prost",
+ "rand 0.9.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -1415,13 +1414,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -2680,16 +2678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
-dependencies = [
- "zerocopy-derive 0.8.23",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -2697,17 +2686,6 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ strip = "symbols"
 default = ["otlp"]
 otlp = [
     "dep:opentelemetry-proto",
-    "dep:opentelemetry",
-    "dep:opentelemetry_sdk",
+
+
     "dep:tracing-core",
     "dep:prost",
 ]
@@ -56,11 +56,10 @@ tokio-util = "0.7.14"
 
 # OTLP dependencies
 opentelemetry-proto = { version = "0.28.0", default-features = false, features = ["gen-tonic-messages", "logs", "trace", "metrics"], optional = true }
-opentelemetry = { version = "0.28.0", default-features = false, features = ["trace"], optional = true }
-opentelemetry_sdk = { version = "0.28.0", default-features = false, features = ["trace"], optional = true }
 tracing-core = {version = "0.1.32", optional = true }
 prost = {version = "0.13.5", optional = true }
 axum-extra = { version = "0.10.0", default-features = false }
+rand = "0.9.1"
 
 
 

--- a/src/otlp/log.rs
+++ b/src/otlp/log.rs
@@ -10,13 +10,13 @@ use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 
 use tracing::field::{Field, Visit};
 
-use opentelemetry::trace::{SpanId, TraceId};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::any_value;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
 use opentelemetry_proto::tonic::resource::v1::Resource;
 
+use crate::otlp::trace::{SpanId, TraceId};
 use crate::otlp::Toilet;
 use crate::time::time_unix_ns;
 use crate::USER_AGENT;
@@ -58,8 +58,8 @@ fn build_logs_export_body(
     }
 }
 
-/// Tracing Layer for pushing logs to an OTLP consumer.
 /// Relies on [TraceId] and [SpanId] to be available in the Event's Span, see [crate::otlp::trace::SpanIdLayer]
+/// Tracing Layer for pushing logs to an OTLP consumer.
 #[derive(Debug, Clone)]
 pub struct OtlpLogLayer {
     otlp_endpoint: String,
@@ -165,8 +165,8 @@ where
                 )),
             }),
             attributes: vec![],
-            trace_id: trace_id.to_bytes().into(),
-            span_id: span_id.to_bytes().into(),
+            trace_id: trace_id.into(),
+            span_id: span_id.into(),
             ..LogRecord::default()
         };
 


### PR DESCRIPTION
Replaces the use of `TraceId`, `SpanId` and the random generator with my own implementation.