### PR TITLE
chore(deps): Remove opentelemetry group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,3 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "deps"
-    groups:
-      opentelemetry:
-        patterns:
-        - "opentelemetry*"


### PR DESCRIPTION
since `opentelemetry_proto` is now the only otel dependency there is no need for a group anymore.

related: #214