### PR TITLE
refactor(otlp): Remove the `otlp` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,6 @@ opt-level = "s"
 lto = true
 strip = "symbols"
 
-[features]
-default = ["otlp"]
-otlp = [
-    "dep:opentelemetry-proto",
-
-
-    "dep:tracing-core",
-    "dep:prost",
-]
-
-
 [dependencies]
 exitcode = "1.1.2"
 oci-spec = { version = "0.7.1", default-features = false, features = ["image", "distribution"] }
@@ -53,14 +42,11 @@ time = { version = "0.3.41", features = ["formatting"] }
 axum = { version = "0.8.1", default-features = false, features = ["multipart","macros", "tokio", "http1", "json"] }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread", "signal", "time"] }
 tokio-util = "0.7.15"
-
-# OTLP dependencies
-opentelemetry-proto = { version = "0.28.0", default-features = false, features = ["gen-tonic-messages", "logs", "trace", "metrics"], optional = true }
-tracing-core = {version = "0.1.32", optional = true }
-prost = {version = "0.13.5", optional = true }
+opentelemetry-proto = { version = "0.28.0", default-features = false, features = ["gen-tonic-messages", "logs", "trace", "metrics"]}
+tracing-core = {version = "0.1.32"}
+prost = {version = "0.13.5"}
 axum-extra = { version = "0.10.1", default-features = false }
 rand = "0.9.1"
-
 
 
 [dev-dependencies]

--- a/src/otlp/mod.rs
+++ b/src/otlp/mod.rs
@@ -28,6 +28,8 @@ use tracing_subscriber::registry::LookupSpan;
 ///
 /// Returns the amended Subscriber and a JoinHandle for the background Task.
 /// After canceling the cancel_token, await the JoinHandle to ensure everything gets flushed.
+///
+/// OTLP tracing won't be set up if otlp_endpoint or otlp_auth is None.
 pub fn otlp<S>(
     subscriber: S,
     otlp_endpoint: Option<String>,


### PR DESCRIPTION
OTLP is always included in the build, I did not test if building without `otlp` works and pyoci is not published as a library so I doubt anyone was building pyoci without `otlp`.

At runtime OTLP is not used if the OTLP_ENDPOINT and OTLP_AUTH are not set.