### PR TITLE
refactor(ci): Trigger release build/deploy on tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,35 +1,13 @@
 name: Publish
 
 on:
-  # Tests docker build without pushing
   push:
     branches:
       - main
+    tags:
+      - "*"
+
   pull_request:
-
-  # Manually, or from another workflow, trigger build of a new version
-  workflow_call:
-    inputs:
-      version:
-        description: 'SemVer version to create'
-        required: true
-        type: string
-      publish:
-        description: 'Publish the new version'
-        required: true
-        type: boolean
-
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Manually create a new SemVer version, will not create a release or tag, use with caution"
-        required: true
-        type: string
-      publish:
-        description: 'Publish the new version'
-        required: false
-        type: boolean
-        default: false
 
 
 concurrency:
@@ -63,8 +41,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag
-            type=semver,value=${{ inputs.version }},pattern={{version}}
-            type=semver,value=${{ inputs.version }},pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=sha
 
       - name: Set up Docker Buildx
@@ -85,7 +63,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           load: true
-          push: ${{ inputs.publish || false }}
+          push: ${{ github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -98,3 +76,16 @@ jobs:
       - run: just test-smoke
       - run: docker compose logs pyoci
         working-directory: ./docker
+
+  deploy:
+    name: Deploy
+    needs: [build]
+    if: github.ref_type == 'tag'
+    uses: ./.github/workflows/deploy.yaml
+    with:
+      version: ${{ needs.build.outputs.version }}
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+      packages: write

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Please
 
 on:
   push:
@@ -20,37 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    outputs:
-      version: ${{ steps.release-please.outputs.major }}.${{ steps.release-please.outputs.minor }}.${{ steps.release-please.outputs.patch }}
-      publish: ${{ steps.release-please.outputs.release_created }}
-
     steps:
       - uses: googleapis/release-please-action@v4
         id: release-please
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  publish:
-    name: Publish
-    needs: [release]
-    if: ${{ needs.release.outputs.publish  == 'true'}}
-    uses: ./.github/workflows/publish.yaml
-    with:
-      version: ${{ needs.release.outputs.version }}
-      publish: ${{ needs.release.outputs.publish  == 'true'}}
-    permissions:
-      contents: read
-      packages: write
-
-  deploy:
-    name: Deploy
-    needs: [release, publish]
-    if: ${{ needs.release.outputs.publish  == 'true'}}
-    uses: ./.github/workflows/deploy.yaml
-    with:
-      version: ${{ needs.release.outputs.version }}
-    secrets: inherit
-    permissions:
-      contents: read
-      id-token: write
-      packages: write


### PR DESCRIPTION
Releases were triggered by an output of release-please on push to `main`.

This PR changes the trigger to a `tag` event.