### PR TITLE
chore(ci): Be explicit about secrets used in reusable workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,17 @@ on:
       version:
         description: 'Version to deploy'
         type: string
+    secrets:
+      AZURE_CLIENT_ID:
+        description: 'Azure Client ID'
+        required: true
+      AZURE_TENANT_ID:
+        description: 'Azure Tenant ID'
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        description: 'Azure Subscription ID'
+        required: true
+
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -23,6 +23,7 @@ jobs:
       # pyoci.com scales down to 0 replicas
       # allow a longer request time if a cold start is needed
       POETRY_REQUESTS_TIMEOUT: 30
+      TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -38,16 +39,19 @@ jobs:
 
       - name: Publish
         run: |
-          just examples poetry-publish "${{ steps.version.outputs.VERSION }}" "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}" "https://pyoci.com/ghcr.io/allexveldman/"
+          just examples poetry-publish "${{ steps.version.outputs.VERSION }}" "${{ github.actor }}" "$TOKEN" "https://pyoci.com/ghcr.io/allexveldman/"
 
       - name: Install
         run: |
-          just examples poetry-install "${{ steps.version.outputs.VERSION }}" "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}" "https://pyoci.com/ghcr.io/allexveldman/"
+          just examples poetry-install "${{ steps.version.outputs.VERSION }}" "${{ github.actor }}" "$TOKEN" "https://pyoci.com/ghcr.io/allexveldman/"
 
   uv:
     name: uv
     runs-on: ubuntu-latest
     timeout-minutes: 2
+
+    env:
+      TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -63,8 +67,8 @@ jobs:
 
       - name: Publish
         run: |
-          just examples uv-publish "${{ steps.version.outputs.VERSION }}" "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}" "https://pyoci.com/ghcr.io/allexveldman/"
+          just examples uv-publish "${{ steps.version.outputs.VERSION }}" "${{ github.actor }}" "$TOKEN" "https://pyoci.com/ghcr.io/allexveldman/"
 
       - name: Install
         run: |
-          just examples uv-install "${{ steps.version.outputs.VERSION }}" "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}" "https://pyoci.com/ghcr.io/allexveldman/"
+          just examples uv-install "${{ steps.version.outputs.VERSION }}" "${{ github.actor }}" "$TOKEN" "https://pyoci.com/ghcr.io/allexveldman/"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,7 +84,10 @@ jobs:
     uses: ./.github/workflows/deploy.yaml
     with:
       version: ${{ needs.build.outputs.version }}
-    secrets: inherit
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     permissions:
       contents: read
       id-token: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -9,7 +9,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.26
+    rev: v1.7.7
     hooks:
       - id: actionlint
 
@@ -24,7 +24,7 @@ repos:
 
       - id: clippy
         name: Clippy
-        stages: [ commit ]
+        stages: [ pre-commit ]
         types: [ file, rust ]
         pass_filenames: false
         language: system


### PR DESCRIPTION
The called workflow no longer inherits the secrets of the caller, instead only the specific secrets needed are passed on.

This also no longer expands the GITHUB_TOKEN secret in the run commands in the examples workflow, instead an environment variable is used.