### PR TITLE
chore(docker): Add `--no-install-recommends` and clean cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,11 @@ ARG BUILDKIT_SBOM_SCAN_STAGE=true
 FROM rust:1.81.0 AS builder
 
 RUN rustup target add x86_64-unknown-linux-musl
-RUN apt update && apt install -y musl-tools musl-dev
+RUN apt update \
+    && apt install --no-install-recommends -y \
+    musl-tools \
+    musl-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -u 10001 pyoci
 


### PR DESCRIPTION
This should lower the layer size of the apt step.