### PR TITLE
chore(docker): Don't cache when building a release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,6 +62,7 @@ jobs:
           file: docker/Dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          no-cache: ${{ github.ref_type == 'tag' }}
           load: true
           push: ${{ github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This ensures we pull the latest state of upstream images and dependencies when creating a release.

ref: https://docs.docker.com/build/building/best-practices/#rebuild-your-images-often