### PR TITLE
fix(release): Tag workflow not triggered

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write  # needed for creating labels
   pull-requests: write
 
 jobs:
@@ -24,5 +25,5 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release-please
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
 


### PR DESCRIPTION
After #243 the release build is no longer triggered when release-please creates the tag.

Use a PAT instead of the GITHUB_TOKEN so release-please created tags actually trigger the tag workflow