### PR TITLE
refactor: Split the OCI implementation from PyOci.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -15,8 +15,8 @@ use serde::{ser::SerializeMap, Serialize, Serializer};
 use tracing::{debug, info_span, Instrument};
 
 use crate::{
+    error::PyOciError,
     package::{Package, WithFileName},
-    pyoci::PyOciError,
     Env, PyOci,
 };
 
@@ -503,7 +503,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::pyoci::digest;
+    use crate::oci::digest;
 
     use axum::{
         body::{to_bytes, Body},

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,37 @@
+use axum::response::IntoResponse;
+use http::StatusCode;
+
+#[derive(Debug)]
+pub struct PyOciError {
+    pub status: StatusCode,
+    pub message: String,
+}
+
+impl std::error::Error for PyOciError {}
+
+impl std::fmt::Display for PyOciError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}: {}", self.status, self.message)
+    }
+}
+
+impl IntoResponse for PyOciError {
+    fn into_response(self) -> axum::response::Response {
+        (self.status, self.message).into_response()
+    }
+}
+
+impl From<(StatusCode, &str)> for PyOciError {
+    fn from((status, message): (StatusCode, &str)) -> Self {
+        PyOciError {
+            status,
+            message: message.to_string(),
+        }
+    }
+}
+
+impl From<(StatusCode, String)> for PyOciError {
+    fn from((status, message): (StatusCode, String)) -> Self {
+        PyOciError { status, message }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,16 @@ mod otlp;
 mod package;
 // PyOci client
 mod pyoci;
+// OCI protocol
+mod oci;
 // HTTP Transport
 mod transport;
 // HTTP Services
 mod service;
 // Wrapper around time
 mod time;
+// Error type
+mod error;
 
 use pyoci::PyOci;
 use tokio::task::JoinHandle;

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -1,0 +1,704 @@
+use std::{
+    collections::{BTreeSet, HashMap},
+    str::FromStr,
+};
+
+use anyhow::{bail, Context, Result};
+use base16ct::lower::encode_string as hex_encode;
+use http::{HeaderValue, StatusCode};
+use oci_spec::{
+    distribution::TagList,
+    image::{
+        Arch, Descriptor, DescriptorBuilder, Digest as OciDigest, ImageIndex, ImageManifest, Os,
+        Platform, PlatformBuilder, Sha256Digest,
+    },
+};
+use reqwest::Response;
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use crate::{
+    error::PyOciError,
+    package::{Package, WithFileName},
+    transport::HttpTransport,
+};
+
+/// Build an URL from a format string while sanitizing the parameters
+///
+/// Note that if the resulting path is an absolute URL, the registry URL is ignored.
+/// For more info, see [`Url::join`]
+///
+/// Returns Err when a parameter fails sanitization
+macro_rules! build_url {
+    ($url:expr, $uri:literal, $($param:expr),+) => {{
+            let uri = format!(
+                $uri,
+                $(sanitize($param)?,)*
+            );
+            let mut new_url = $url.clone();
+            new_url.set_path("");
+            new_url.join(&uri)?
+        }}
+}
+
+/// Sanitize a string
+///
+/// Returns an error if the string contains ".."
+fn sanitize(value: &str) -> Result<&str> {
+    match value {
+        value if value.contains("..") => bail!("Invalid value: {}", value),
+        value => Ok(value),
+    }
+}
+
+/// Container for a Blob/Layer data, combined with a Descriptor
+pub struct Blob {
+    data: Vec<u8>,
+    descriptor: Descriptor,
+}
+
+impl Blob {
+    pub fn new(data: Vec<u8>, artifact_type: &str) -> Self {
+        let digest = digest(&data);
+        let descriptor = DescriptorBuilder::default()
+            .media_type(artifact_type)
+            .digest(digest)
+            .size(data.len() as u64)
+            .build()
+            .expect("valid Descriptor");
+        Blob { data, descriptor }
+    }
+
+    pub fn descriptor(&self) -> &Descriptor {
+        &self.descriptor
+    }
+}
+
+/// Calculate the digest of the provided data
+pub fn digest(data: impl AsRef<[u8]>) -> OciDigest {
+    let sha = <Sha256 as Digest>::digest(data);
+    Sha256Digest::from_str(&hex_encode(&sha))
+        .expect("Invalid Digest")
+        .into()
+}
+
+/// Return type for ``pull_manifest``
+/// as the same endpoint can return both a manifest and a manifest index
+#[derive(Debug)]
+pub enum Manifest {
+    Index(Box<ImageIndex>),
+    Manifest(Box<ImageManifest>),
+}
+
+/// Container for a ImageManifest combined with a Platform
+#[derive(Debug)]
+pub struct PlatformManifest {
+    pub manifest: ImageManifest,
+    pub platform: Platform,
+}
+
+impl PlatformManifest {
+    pub fn new(manifest: ImageManifest, package: &Package<WithFileName>) -> Self {
+        let platform = PlatformBuilder::default()
+            .architecture(Arch::Other(package.oci_architecture().to_string()))
+            .os(Os::Other("any".to_string()))
+            .build()
+            .expect("valid Platform");
+        PlatformManifest { manifest, platform }
+    }
+
+    pub fn descriptor(&self, annotations: HashMap<String, String>) -> Descriptor {
+        let (digest, data) = self.digest();
+        DescriptorBuilder::default()
+            .media_type("application/vnd.oci.image.manifest.v1+json")
+            .digest(digest)
+            .size(data.len() as u64)
+            .platform(self.platform.clone())
+            .annotations(annotations)
+            .build()
+            .expect("Valid PlatformManifest Descriptor")
+    }
+
+    fn digest(&self) -> (OciDigest, String) {
+        let data = serde_json::to_string(&self.manifest).expect("valid json");
+        (digest(&data), data)
+    }
+}
+
+/// Implements the client side of the OCI distribution specification
+#[derive(Debug, Clone)]
+pub struct Oci {
+    registry: Url,
+    transport: HttpTransport,
+}
+
+/// Low-level functionality for interacting with the OCI registry
+impl Oci {
+    pub fn new(registry: Url, auth: Option<HeaderValue>) -> Result<Oci> {
+        Ok(Oci {
+            registry,
+            transport: HttpTransport::new(auth)?,
+        })
+    }
+    /// Push a blob to the registry using POST then PUT method
+    ///
+    /// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#post-then-put
+    #[tracing::instrument(skip_all, fields(otel.name = name))]
+    pub async fn push_blob(
+        &mut self,
+        // Name of the package, including namespace. e.g. "library/alpine"
+        name: &str,
+        blob: Blob,
+    ) -> Result<()> {
+        let digest = blob.descriptor.digest().to_string();
+        let response = self
+            .transport
+            .send(
+                self.transport
+                    .head(build_url!(&self.registry, "/v2/{}/blobs/{}", name, &digest)),
+            )
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => {
+                tracing::info!("Blob already exists: {name}:{digest}");
+                return Ok(());
+            }
+            StatusCode::NOT_FOUND => {}
+            status => {
+                return Err(PyOciError::from((status, response.text().await?)).into());
+            }
+        }
+
+        let url = build_url!(&self.registry, "/v2/{}/blobs/uploads/", name);
+        let request = self
+            .transport
+            .post(url)
+            .header("Content-Type", "application/octet-stream");
+        let response = self.transport.send(request).await?;
+        let location = match response.status() {
+            StatusCode::CREATED => return Ok(()),
+            StatusCode::ACCEPTED => response
+                .headers()
+                .get("Location")
+                .context("Registry response did not contain a Location header")?
+                .to_str()
+                .context("Failed to parse Location header as ASCII")?,
+            status => {
+                return Err(PyOciError::from((status, response.text().await?)).into());
+            }
+        };
+        let mut url: Url = build_url!(&self.registry, "{}", location);
+        // `append_pair` percent-encodes the values as application/x-www-form-urlencoded.
+        // ghcr.io seems to be fine with a percent-encoded digest but this could be an issue with
+        // other registries.
+        url.query_pairs_mut().append_pair("digest", &digest);
+
+        let request = self
+            .transport
+            .put(url)
+            .header("Content-Type", "application/octet-stream")
+            .header("Content-Length", blob.data.len().to_string())
+            .body(blob.data);
+        let response = self.transport.send(request).await?;
+        match response.status() {
+            StatusCode::CREATED => {}
+            status => {
+                return Err(PyOciError::from((status, response.text().await?)).into());
+            }
+        }
+        tracing::debug!(
+            "Blob-location: {}",
+            response
+                .headers()
+                .get("Location")
+                .expect("valid Location header")
+                .to_str()
+                .expect("valid Location header value")
+        );
+        Ok(())
+    }
+
+    /// Pull a blob from the registry
+    ///
+    /// This returns the raw response so the caller can handle the blob as needed
+    #[tracing::instrument(skip_all, fields(otel.name = name))]
+    pub async fn pull_blob(
+        &mut self,
+        // Name of the package, including namespace. e.g. "library/alpine"
+        name: String,
+        // Descriptor of the blob to pull
+        descriptor: Descriptor,
+    ) -> Result<Response> {
+        let digest = descriptor.digest().to_string();
+        let url = build_url!(&self.registry, "/v2/{}/blobs/{}", &name, &digest);
+        let request = self.transport.get(url);
+        let response = self.transport.send(request).await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(response),
+            status => Err(PyOciError::from((status, response.text().await?)).into()),
+        }
+    }
+
+    /// List the available tags for a package
+    ///
+    /// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-tags
+    #[tracing::instrument(skip_all, fields(otel.name = name))]
+    pub async fn list_tags(&mut self, name: &str) -> anyhow::Result<BTreeSet<String>> {
+        let url = build_url!(&self.registry, "/v2/{}/tags/list", name);
+        let request = self.transport.get(url);
+        let response = self.transport.send(request).await?;
+        match response.status() {
+            StatusCode::OK => {}
+            status => return Err(PyOciError::from((status, response.text().await?)).into()),
+        }
+        let mut link_header = match response.headers().get("link") {
+            Some(link) => Some(Link::try_from(link)?),
+            None => None,
+        };
+        let mut tags: BTreeSet<String> = response
+            .json::<TagList>()
+            .await?
+            .tags()
+            .iter()
+            .map(|f| f.to_owned())
+            .collect();
+        while let Some(ref link) = link_header {
+            // Follow the link headers as long as a Link header is returned
+            let mut url = self.registry.clone();
+            url.set_path("");
+            let url = url.join(&link.0)?;
+            let request = self.transport.get(url);
+            let response = self.transport.send(request).await?;
+            match response.status() {
+                StatusCode::OK => {}
+                status => return Err(PyOciError::from((status, response.text().await?)).into()),
+            }
+            link_header = match response.headers().get("link") {
+                Some(link) => Some(Link::try_from(link)?),
+                None => None,
+            };
+            let tag_list = response.json::<TagList>().await?;
+            tags.extend(tag_list.tags().iter().map(|f| f.to_owned()));
+        }
+
+        Ok(tags)
+    }
+
+    /// Push a manifest to the registry
+    ///
+    /// ImageIndex will be pushed with a version tag if version is set
+    /// ImageManifest will always be pushed with a digest reference
+    #[tracing::instrument(skip_all, fields(otel.name = name, otel.version = version))]
+    pub async fn push_manifest(
+        &mut self,
+        name: &str,
+        manifest: Manifest,
+        version: Option<&str>,
+    ) -> Result<()> {
+        let (url, data, content_type) = match manifest {
+            Manifest::Index(index) => {
+                let version = version.context("`version` required for pushing an ImageIndex")?;
+                let url = build_url!(&self.registry, "v2/{}/manifests/{}", name, version);
+                let data = serde_json::to_string(&index)?;
+                (url, data, "application/vnd.oci.image.index.v1+json")
+            }
+            Manifest::Manifest(manifest) => {
+                let data = serde_json::to_string(&manifest)?;
+                let data_digest = digest(&data);
+                let url = build_url!(
+                    &self.registry,
+                    "/v2/{}/manifests/{}",
+                    name,
+                    data_digest.as_ref()
+                );
+                (url, data, "application/vnd.oci.image.manifest.v1+json")
+            }
+        };
+
+        let request = self
+            .transport
+            .put(url)
+            .header("Content-Type", content_type)
+            .body(data);
+        let response = self.transport.send(request).await?;
+        match response.status() {
+            StatusCode::CREATED => {}
+            status => return Err(PyOciError::from((status, response.text().await?)).into()),
+        }
+        Ok(())
+    }
+
+    /// Pull a manifest from the registry
+    ///
+    /// If the manifest does not exist, Ok<None> is returned
+    /// If any other error happens, an Err is returned
+    #[tracing::instrument(skip_all, fields(otel.name = name, otel.reference = reference))]
+    pub async fn pull_manifest(&mut self, name: &str, reference: &str) -> Result<Option<Manifest>> {
+        let url = build_url!(&self.registry, "/v2/{}/manifests/{}", name, reference);
+        let request = self.transport.get(url).header(
+            "Accept",
+            "application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json",
+        );
+        let response = self.transport.send(request).await?;
+        match response.status() {
+            StatusCode::NOT_FOUND => return Ok(None),
+            StatusCode::OK => {}
+            status => return Err(PyOciError::from((status, response.text().await?)).into()),
+        }
+
+        match response.headers().get("Content-Type") {
+            Some(value) if value == "application/vnd.oci.image.index.v1+json" => {
+                Ok(Some(Manifest::Index(Box::new(
+                    response
+                        .json::<ImageIndex>()
+                        .await
+                        .expect("valid Index json"),
+                ))))
+            }
+            Some(value) if value == "application/vnd.oci.image.manifest.v1+json" => {
+                Ok(Some(Manifest::Manifest(Box::new(
+                    response
+                        .json::<ImageManifest>()
+                        .await
+                        .expect("valid Manifest json"),
+                ))))
+            }
+            Some(content_type) => bail!("Unknown Content-Type: {}", content_type.to_str().unwrap()),
+            None => bail!("Missing Content-Type header"),
+        }
+    }
+
+    /// Delete a tag or manifest
+    ///
+    /// reference: tag or digest of the manifest to delete
+    /// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#content-management
+    #[tracing::instrument(skip_all, fields(otel.name = name, otel.reference = reference))]
+    pub async fn delete_manifest(&mut self, name: &str, reference: &str) -> Result<()> {
+        let url = build_url!(&self.registry, "/v2/{}/manifests/{}", name, reference);
+        let request = self.transport.delete(url);
+        let response = self.transport.send(request).await?;
+        match response.status() {
+            StatusCode::ACCEPTED => Ok(()),
+            status => Err(PyOciError::from((status, response.text().await?)).into()),
+        }
+    }
+}
+
+struct Link(String);
+
+impl TryFrom<&HeaderValue> for Link {
+    type Error = PyOciError;
+
+    fn try_from(value: &HeaderValue) -> std::result::Result<Self, Self::Error> {
+        let value = match value.to_str() {
+            Ok(value) => value,
+            _ => {
+                return Err(PyOciError::from((
+                    StatusCode::BAD_GATEWAY,
+                    "OCI registry provided invalid Link header",
+                )))
+            }
+        };
+        let parts = value.split(';').collect::<Vec<_>>();
+        tracing::debug!("{parts:?}");
+        let target = match parts.first().map(|f| f.trim()) {
+            Some(target) if target.starts_with('<') && target.ends_with('>') => {
+                target.strip_prefix('<').unwrap().strip_suffix('>').unwrap()
+            }
+            _ => {
+                return Err(PyOciError::from((
+                    StatusCode::BAD_GATEWAY,
+                    "OCI registry provided an invalid Link target",
+                )))
+            }
+        };
+
+        // Check the Link contains the correct "rel"
+        let mut valid_rel = false;
+        for param in &parts[1..] {
+            match param.split_once('=') {
+                Some((key, value)) if key.trim() == "rel" && value.trim() == "\"next\"" => {
+                    valid_rel = true
+                }
+                _ => {}
+            }
+        }
+        if !valid_rel {
+            return Err(PyOciError::from((
+                StatusCode::BAD_GATEWAY,
+                "OCI registry provide invalid Link rel",
+            )));
+        }
+        Ok(Link(target.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_build_url() -> Result<()> {
+        let url = build_url!(
+            &Url::parse("https://example.com").expect("valid url"),
+            "/foo/{}/",
+            "latest"
+        );
+        assert_eq!(url.as_str(), "https://example.com/foo/latest/");
+        Ok(())
+    }
+
+    #[test]
+    fn test_build_url_absolute() -> Result<()> {
+        let url = build_url!(
+            &Url::parse("https://example.com").expect("valid url"),
+            "{}/foo?bar=baz&qaz=sha:123",
+            "http://pyoci.nl"
+        );
+        assert_eq!(url.as_str(), "http://pyoci.nl/foo?bar=baz&qaz=sha:123");
+        Ok(())
+    }
+
+    #[test]
+    fn test_build_url_double_period() {
+        let x = || -> Result<Url> {
+            Ok(build_url!(
+                &Url::parse("https://example.com").expect("valid url"),
+                "/foo/{}/",
+                ".."
+            ))
+        }();
+        assert!(x.is_err());
+    }
+
+    /// Test if a relative Location header is properly handled
+    #[tokio::test]
+    async fn test_push_blob_location_relative() {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        let mut mocks = vec![];
+        // Mock the server, in order of expected requests
+
+        // HEAD request to check if blob exists
+        mocks.push(
+            server
+                .mock(
+                    "HEAD",
+                    "/v2/mockserver/foobar/blobs/sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                )
+                .with_status(404)
+                .create_async()
+                .await,
+        );
+        // POST request initiating blob upload
+        mocks.push(
+            server
+                .mock("POST", "/v2/mockserver/foobar/blobs/uploads/")
+                .with_status(202) // ACCEPTED
+                .with_header(
+                    "Location",
+                    "/v2/mockserver/foobar/blobs/uploads/1?_state=uploading",
+                )
+                .create_async()
+                .await,
+        );
+        // PUT request to upload blob
+        mocks.push(
+            server
+                .mock(
+                    "PUT",
+                    "/v2/mockserver/foobar/blobs/uploads/1?_state=uploading&digest=sha256%3A2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                )
+                .with_status(201) // CREATED
+                .create_async()
+                .await,
+        );
+
+        let mut client = Oci::new(Url::parse(&url).expect("valid url"), None).unwrap();
+        let blob = Blob::new("hello".into(), "application/octet-stream");
+        let _ = client.push_blob("mockserver/foobar", blob).await;
+
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+    }
+    /// Test if an absolute Location header is properly handled
+    #[tokio::test]
+    async fn test_push_blob_location_absolute() {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        let mut mocks = vec![];
+        // Mock the server, in order of expected requests
+
+        // HEAD request to check if blob exists
+        mocks.push(
+            server
+                .mock(
+                    "HEAD",
+                    "/v2/mockserver/foobar/blobs/sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                )
+                .with_status(404)
+                .create_async()
+                .await,
+        );
+        // POST request initiating blob upload
+        mocks.push(
+            server
+                .mock("POST", "/v2/mockserver/foobar/blobs/uploads/")
+                .with_status(202) // ACCEPTED
+                .with_header(
+                    "Location",
+                    &format!("{url}/v2/mockserver/foobar/blobs/uploads/1?_state=uploading"),
+                )
+                .create_async()
+                .await,
+        );
+        // PUT request to upload blob
+        mocks.push(
+            server
+                .mock(
+                    "PUT",
+                    "/v2/mockserver/foobar/blobs/uploads/1?_state=uploading&digest=sha256%3A2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                )
+                .with_status(201) // CREATED
+                .create_async()
+                .await,
+        );
+
+        let mut client = Oci::new(Url::parse(&url).expect("valid url"), None).unwrap();
+        let blob = Blob::new("hello".into(), "application/octet-stream");
+        let _ = client.push_blob("mockserver/foobar", blob).await;
+
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn list_tags() {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        let tags = r#"{
+          "name": "mockserver/bar",
+          "tags": [
+            "1",
+            "2",
+            "3"
+          ]
+        }"#;
+        server
+            .mock("GET", "/v2/mockserver/bar/tags/list")
+            .with_status(200)
+            .with_body(tags)
+            .create_async()
+            .await;
+
+        let mut pyoci = Oci::new(Url::parse(&url).expect("valid url"), None).unwrap();
+
+        let result = pyoci
+            .list_tags("mockserver/bar")
+            .await
+            .expect("Valid response");
+
+        assert_eq!(
+            result,
+            BTreeSet::from(["1".to_string(), "2".to_string(), "3".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn list_tags_link_header() {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        server
+            .mock("GET", "/v2/mockserver/bar/tags/list")
+            .with_header(
+                "Link",
+                "</v2/mockserver/bar/tags/list?n=3&last=3>; rel=\"next\"",
+            )
+            .with_status(200)
+            .with_body(
+                r#"{
+                  "name": "mockserver/bar",
+                  "tags": [
+                    "1",
+                    "2",
+                    "3"
+                  ]
+                }"#,
+            )
+            .create_async()
+            .await;
+
+        server
+            .mock("GET", "/v2/mockserver/bar/tags/list?n=3&last=3")
+            .with_header(
+                "Link",
+                "</v2/mockserver/bar/tags/list?n=3&last=6>; rel=\"next\"",
+            )
+            .with_status(200)
+            .with_body(
+                r#"{
+                  "name": "mockserver/bar",
+                  "tags": [
+                    "4",
+                    "5",
+                    "6"
+                  ]
+                }"#,
+            )
+            .create_async()
+            .await;
+
+        server
+            .mock("GET", "/v2/mockserver/bar/tags/list?n=3&last=6")
+            .with_status(200)
+            .with_body(
+                r#"{
+                  "name": "mockserver/bar",
+                  "tags": [
+                    "7"
+                  ]
+                }"#,
+            )
+            .create_async()
+            .await;
+
+        let mut pyoci = Oci::new(Url::parse(&url).expect("valid url"), None).unwrap();
+
+        let result = pyoci
+            .list_tags("mockserver/bar")
+            .await
+            .expect("Valid response");
+
+        assert_eq!(
+            result,
+            BTreeSet::from([
+                "1".to_string(),
+                "2".to_string(),
+                "3".to_string(),
+                "4".to_string(),
+                "5".to_string(),
+                "6".to_string(),
+                "7".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn link() {
+        let link = Link::try_from(&HeaderValue::from_static("</v2/allexveldman/hello_world/tags/list?last=0.0.1-example.1.poetry.2824051&n=5>; rel=\"next\"")).unwrap();
+        assert_eq!(
+            link.0,
+            "/v2/allexveldman/hello_world/tags/list?last=0.0.1-example.1.poetry.2824051&n=5"
+        )
+    }
+}

--- a/src/package.rs
+++ b/src/package.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use http::StatusCode;
 use serde::{ser::SerializeMap, Serialize, Serializer};
 
-use crate::pyoci::PyOciError;
+use crate::error::PyOciError;
 
 pub trait FileState {}
 

--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -1,211 +1,51 @@
-use anyhow::{bail, Context, Error, Result};
-use axum::response::IntoResponse;
-use base16ct::lower::encode_string as hex_encode;
+use anyhow::{bail, Error, Result};
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
 use http::HeaderValue;
 use http::StatusCode;
-use oci_spec::{
-    distribution::TagList,
-    image::{
-        Arch, Descriptor, DescriptorBuilder, Digest as OciDigest, ImageIndex, ImageIndexBuilder,
-        ImageManifest, ImageManifestBuilder, MediaType, Os, Platform, PlatformBuilder,
-        Sha256Digest, SCHEMA_VERSION,
-    },
+use oci_spec::image::{
+    ImageIndex, ImageIndexBuilder, ImageManifestBuilder, MediaType, SCHEMA_VERSION,
 };
 use reqwest::Response;
-use serde::Deserialize;
 use serde_json::to_string_pretty;
-use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use std::collections::HashMap;
-use std::str::FromStr;
 use time::format_description::well_known::Rfc3339;
 use url::Url;
 
+use crate::error::PyOciError;
+use crate::oci::Blob;
+use crate::oci::Manifest;
+use crate::oci::Oci;
+use crate::oci::PlatformManifest;
 use crate::time::now_utc;
 
 use crate::package::{Package, WithFileName, WithoutFileName};
-use crate::transport::{HttpTransport, Transport};
 use crate::ARTIFACT_TYPE;
 
-/// Build an URL from a format string while sanitizing the parameters
-///
-/// Note that if the resulting path is an absolute URL, the registry URL is ignored.
-/// For more info, see [`Url::join`]
-///
-/// Returns Err when a parameter fails sanitization
-macro_rules! build_url {
-    ($pyoci:expr, $uri:literal, $($param:expr),+) => {{
-            let uri = format!(
-                $uri,
-                $(sanitize($param)?,)*
-            );
-            let mut new_url = $pyoci.registry.clone();
-            new_url.set_path("");
-            new_url.join(&uri)?
-        }}
-}
-
-/// Sanitize a string
-///
-/// Returns an error if the string contains ".."
-fn sanitize(value: &str) -> Result<&str> {
-    match value {
-        value if value.contains("..") => bail!("Invalid value: {}", value),
-        value => Ok(value),
-    }
-}
-
-/// Return type for ``pull_manifest``
-/// as the same endpoint can return both a manifest and a manifest index
-#[derive(Debug)]
-pub enum Manifest {
-    Index(Box<ImageIndex>),
-    Manifest(Box<ImageManifest>),
-}
-
-/// Container for a ImageManifest combined with a Platform
-#[derive(Debug)]
-struct PlatformManifest {
-    manifest: ImageManifest,
-    platform: Platform,
-}
-
-impl PlatformManifest {
-    fn new(manifest: ImageManifest, package: &Package<WithFileName>) -> Self {
-        let platform = PlatformBuilder::default()
-            .architecture(Arch::Other(package.oci_architecture().to_string()))
-            .os(Os::Other("any".to_string()))
-            .build()
-            .expect("valid Platform");
-        PlatformManifest { manifest, platform }
-    }
-
-    fn descriptor(&self, annotations: HashMap<String, String>) -> Descriptor {
-        let (digest, data) = self.digest();
-        DescriptorBuilder::default()
-            .media_type("application/vnd.oci.image.manifest.v1+json")
-            .digest(digest)
-            .size(data.len() as u64)
-            .platform(self.platform.clone())
-            .annotations(annotations)
-            .build()
-            .expect("Valid PlatformManifest Descriptor")
-    }
-
-    fn digest(&self) -> (OciDigest, String) {
-        let data = serde_json::to_string(&self.manifest).expect("valid json");
-        (digest(&data), data)
-    }
-}
-
-/// Container for a Blob/Layer data, combined with a Descriptor
-struct Blob {
-    data: Vec<u8>,
-    descriptor: Descriptor,
-}
-
-impl Blob {
-    fn new(data: Vec<u8>, artifact_type: &str) -> Self {
-        let digest = digest(&data);
-        let descriptor = DescriptorBuilder::default()
-            .media_type(artifact_type)
-            .digest(digest)
-            .size(data.len() as u64)
-            .build()
-            .expect("valid Descriptor");
-        Blob { data, descriptor }
-    }
-}
-
-pub fn digest(data: impl AsRef<[u8]>) -> OciDigest {
-    let sha = <Sha256 as Digest>::digest(data);
-    Sha256Digest::from_str(&hex_encode(&sha))
-        .expect("Invalid Digest")
-        .into()
-}
-
-#[derive(Debug)]
-pub struct PyOciError {
-    pub status: StatusCode,
-    pub message: String,
-}
-impl std::error::Error for PyOciError {}
-
-impl std::fmt::Display for PyOciError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}: {}", self.status, self.message)
-    }
-}
-
-impl IntoResponse for PyOciError {
-    fn into_response(self) -> axum::response::Response {
-        (self.status, self.message).into_response()
-    }
-}
-
-impl From<(StatusCode, &str)> for PyOciError {
-    fn from((status, message): (StatusCode, &str)) -> Self {
-        PyOciError {
-            status,
-            message: message.to_string(),
-        }
-    }
-}
-
-impl From<(StatusCode, String)> for PyOciError {
-    fn from((status, message): (StatusCode, String)) -> Self {
-        PyOciError { status, message }
-    }
-}
-
-#[derive(Deserialize)]
-pub struct AuthResponse {
-    #[serde(alias = "access_token")]
-    pub token: String,
-}
-
 /// Client to communicate with the OCI v2 registry
-#[derive(Debug)]
-pub struct PyOci<T> {
-    registry: Url,
-    transport: T,
+#[derive(Debug, Clone)]
+pub struct PyOci {
+    oci: Oci,
 }
 
-impl PyOci<HttpTransport> {
+impl PyOci {
     /// Create a new Client
-    pub fn new(registry: Url, auth: Option<HeaderValue>) -> Result<PyOci<HttpTransport>> {
+    pub fn new(registry: Url, auth: Option<HeaderValue>) -> Result<PyOci> {
         Ok(PyOci {
-            registry,
-            transport: HttpTransport::new(auth)?,
+            oci: Oci::new(registry, auth)?,
         })
     }
 }
 
-impl<T> Clone for PyOci<T>
-where
-    T: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            registry: self.registry.clone(),
-            transport: self.transport.clone(),
-        }
-    }
-}
-
 /// Create/List/Download/Delete Packages
-impl<T> PyOci<T>
-where
-    T: Transport + Clone,
-{
+impl PyOci {
     pub async fn list_package_versions<'a>(
         &mut self,
         package: &'a Package<'a, WithoutFileName>,
     ) -> Result<BTreeSet<String>> {
         let name = package.oci_name();
-        let result = self.list_tags(&name).await?;
+        let result = self.oci.list_tags(&name).await?;
         tracing::debug!("{:?}", result);
         Ok(result)
     }
@@ -219,7 +59,7 @@ where
         package: &'a Package<'a, WithoutFileName>,
         mut n: usize,
     ) -> Result<Vec<Package<'a, WithFileName>>> {
-        let tags = self.list_tags(&package.oci_name()).await?;
+        let tags = self.oci.list_tags(&package.oci_name()).await?;
         let mut files: Vec<Package<WithFileName>> = Vec::new();
         let futures = FuturesUnordered::new();
 
@@ -239,9 +79,6 @@ where
         // We fetch a list of all tags from the OCI registry.
         // For each tag there can be multiple files.
         // We fetch the last `n` tags and for each tag we fetch the file names.
-        // According to the spec the tags list should be in lexical order.
-        // Even for non-spec registries the last-added seems to be at the end of the list
-        // so this will result in the wanted list of tags in most cases.
         for tag in tags.iter().rev().take(n) {
             let pyoci = self.clone();
             futures.push(pyoci.package_info_for_ref(package, tag));
@@ -255,12 +92,16 @@ where
         Ok(files)
     }
 
+    /// Fetch all files for a single version of a package
     pub async fn package_info_for_ref<'a>(
         mut self,
         package: &'a Package<'a, WithoutFileName>,
         reference: &str,
     ) -> Result<Vec<Package<'a, WithFileName>>> {
-        let manifest = self.pull_manifest(&package.oci_name(), reference).await?;
+        let manifest = self
+            .oci
+            .pull_manifest(&package.oci_name(), reference)
+            .await?;
         let index = match manifest {
             Some(Manifest::Index(index)) => index,
             Some(Manifest::Manifest(_)) => {
@@ -310,12 +151,14 @@ where
         Ok(files)
     }
 
+    /// Download a single file of a package
     pub async fn download_package_file(
         &mut self,
         package: &Package<'_, WithFileName>,
     ) -> Result<Response> {
         // Pull index
         let index = match self
+            .oci
             .pull_manifest(&package.oci_name(), &package.oci_tag())
             .await?
         {
@@ -366,6 +209,7 @@ where
         };
 
         let manifest = match self
+            .oci
             .pull_manifest(&package.oci_name(), manifest_descriptor.digest().as_ref())
             .await?
         {
@@ -385,11 +229,14 @@ where
         let [blob_descriptor] = &manifest.layers()[..] else {
             bail!("Image Manifest defines unexpected number of layers, was this package published by pyoci?");
         };
-        self.pull_blob(package.oci_name(), blob_descriptor.to_owned())
+        self.oci
+            .pull_blob(package.oci_name(), blob_descriptor.to_owned())
             .await
     }
 
-    /// Construct and publish the manifests and blob provided.
+    /// Publish a package file
+    ///
+    /// Constructs and publishes the manifests and file data provided.
     ///
     /// The `sha256_digest`, if provided, will be verified against the sha256 of the actual content.
     ///
@@ -431,7 +278,7 @@ where
         );
 
         // Build the Manifest
-        let manifest = self.image_manifest(package, &layer, annotations);
+        let manifest = image_manifest(package, &layer, annotations);
         let index = self
             .image_index(
                 package,
@@ -443,32 +290,14 @@ where
         tracing::debug!("{}", to_string_pretty(&index).unwrap());
         tracing::debug!("{}", to_string_pretty(&manifest.manifest).unwrap());
 
-        self.push_blob(&name, layer).await?;
-        self.push_blob(&name, empty_config()).await?;
-        self.push_manifest(&name, Manifest::Manifest(Box::new(manifest.manifest)), None)
+        self.oci.push_blob(&name, layer).await?;
+        self.oci.push_blob(&name, empty_config()).await?;
+        self.oci
+            .push_manifest(&name, Manifest::Manifest(Box::new(manifest.manifest)), None)
             .await?;
-        self.push_manifest(&name, Manifest::Index(Box::new(index)), Some(&tag))
+        self.oci
+            .push_manifest(&name, Manifest::Index(Box::new(index)), Some(&tag))
             .await
-    }
-
-    /// Get the definition of a new ImageManifest
-    fn image_manifest(
-        &self,
-        package: &Package<'_, WithFileName>,
-        layer: &Blob,
-        annotations: HashMap<String, String>,
-    ) -> PlatformManifest {
-        let config = empty_config();
-        let manifest = ImageManifestBuilder::default()
-            .schema_version(SCHEMA_VERSION)
-            .media_type("application/vnd.oci.image.manifest.v1+json")
-            .artifact_type(ARTIFACT_TYPE)
-            .config(config.descriptor.clone())
-            .layers(vec![layer.descriptor.clone()])
-            .annotations(annotations)
-            .build()
-            .expect("valid ImageManifest");
-        PlatformManifest::new(manifest, package)
     }
 
     /// Create or Update the definition of a new ImageIndex
@@ -482,7 +311,7 @@ where
         let name = package.oci_name();
         let tag = package.oci_tag();
         // Pull an existing index
-        let index = match self.pull_manifest(&name, &tag).await? {
+        let index = match self.oci.pull_manifest(&name, &tag).await? {
             Some(Manifest::Manifest(_)) => {
                 bail!("Expected ImageIndex, got ImageManifest");
             }
@@ -533,12 +362,13 @@ where
         Ok(index)
     }
 
+    /// Delete a package version
     pub async fn delete_package_version(
         &mut self,
         package: &Package<'_, WithFileName>,
     ) -> Result<()> {
         let name = package.oci_name();
-        let index = match self.pull_manifest(&name, &package.oci_tag()).await? {
+        let index = match self.oci.pull_manifest(&name, &package.oci_tag()).await? {
             Some(Manifest::Index(index)) => index,
             Some(Manifest::Manifest(_)) => {
                 bail!("Expected ImageIndex, got ImageManifest");
@@ -561,17 +391,36 @@ where
         for manifest in index.manifests() {
             let digest = manifest.digest().to_string();
             tracing::debug!("Deleting {name}:{digest}");
-            self.delete_manifest(&name, &digest).await?
+            self.oci.delete_manifest(&name, &digest).await?
         }
         Ok(())
     }
+}
+
+/// Get the definition of a new ImageManifest
+fn image_manifest(
+    package: &Package<'_, WithFileName>,
+    layer: &Blob,
+    annotations: HashMap<String, String>,
+) -> PlatformManifest {
+    let config = empty_config();
+    let manifest = ImageManifestBuilder::default()
+        .schema_version(SCHEMA_VERSION)
+        .media_type("application/vnd.oci.image.manifest.v1+json")
+        .artifact_type(ARTIFACT_TYPE)
+        .config(config.descriptor().clone())
+        .layers(vec![layer.descriptor().clone()])
+        .annotations(annotations)
+        .build()
+        .expect("valid ImageManifest");
+    PlatformManifest::new(manifest, package)
 }
 
 /// Check if the provided digest matches the package digest
 ///
 /// Returns the digest if successful
 fn verify_digest(layer: &Blob, expected_digest: Option<String>) -> Result<String> {
-    let package_digest = layer.descriptor.digest().digest();
+    let package_digest = layer.descriptor().digest().digest();
 
     if let Some(sha256_digest) = expected_digest {
         // Verify if the sha256 as provided by the request matches the calculated sha of the
@@ -586,455 +435,18 @@ fn verify_digest(layer: &Blob, expected_digest: Option<String>) -> Result<String
     Ok(package_digest.to_string())
 }
 
-/// Low-level functionality for interacting with the OCI registry
-impl<T> PyOci<T>
-where
-    T: Transport + Clone,
-{
-    /// Push a blob to the registry using POST then PUT method
-    ///
-    /// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#post-then-put
-    #[tracing::instrument(skip_all, fields(otel.name = name))]
-    async fn push_blob(
-        &mut self,
-        // Name of the package, including namespace. e.g. "library/alpine"
-        name: &str,
-        blob: Blob,
-    ) -> Result<()> {
-        let digest = blob.descriptor.digest().to_string();
-        let response = self
-            .transport
-            .send(
-                self.transport
-                    .head(build_url!(&self, "/v2/{}/blobs/{}", name, &digest)),
-            )
-            .await?;
-
-        match response.status() {
-            StatusCode::OK => {
-                tracing::info!("Blob already exists: {name}:{digest}");
-                return Ok(());
-            }
-            StatusCode::NOT_FOUND => {}
-            status => {
-                return Err(PyOciError::from((status, response.text().await?)).into());
-            }
-        }
-
-        let url = build_url!(&self, "/v2/{}/blobs/uploads/", name);
-        let request = self
-            .transport
-            .post(url)
-            .header("Content-Type", "application/octet-stream");
-        let response = self.transport.send(request).await?;
-        let location = match response.status() {
-            StatusCode::CREATED => return Ok(()),
-            StatusCode::ACCEPTED => response
-                .headers()
-                .get("Location")
-                .context("Registry response did not contain a Location header")?
-                .to_str()
-                .context("Failed to parse Location header as ASCII")?,
-            status => {
-                return Err(PyOciError::from((status, response.text().await?)).into());
-            }
-        };
-        let mut url: Url = build_url!(&self, "{}", location);
-        // `append_pair` percent-encodes the values as application/x-www-form-urlencoded.
-        // ghcr.io seems to be fine with a percent-encoded digest but this could be an issue with
-        // other registries.
-        url.query_pairs_mut().append_pair("digest", &digest);
-
-        let request = self
-            .transport
-            .put(url)
-            .header("Content-Type", "application/octet-stream")
-            .header("Content-Length", blob.data.len().to_string())
-            .body(blob.data);
-        let response = self.transport.send(request).await?;
-        match response.status() {
-            StatusCode::CREATED => {}
-            status => {
-                return Err(PyOciError::from((status, response.text().await?)).into());
-            }
-        }
-        tracing::debug!(
-            "Blob-location: {}",
-            response
-                .headers()
-                .get("Location")
-                .expect("valid Location header")
-                .to_str()
-                .expect("valid Location header value")
-        );
-        Ok(())
-    }
-
-    /// Pull a blob from the registry
-    ///
-    /// This returns the raw response so the caller can handle the blob as needed
-    #[tracing::instrument(skip_all, fields(otel.name = name))]
-    async fn pull_blob(
-        &mut self,
-        // Name of the package, including namespace. e.g. "library/alpine"
-        name: String,
-        // Descriptor of the blob to pull
-        descriptor: Descriptor,
-    ) -> Result<Response> {
-        let digest = descriptor.digest().to_string();
-        let url = build_url!(&self, "/v2/{}/blobs/{}", &name, &digest);
-        let request = self.transport.get(url);
-        let response = self.transport.send(request).await?;
-
-        match response.status() {
-            StatusCode::OK => Ok(response),
-            status => Err(PyOciError::from((status, response.text().await?)).into()),
-        }
-    }
-
-    /// List the available tags for a package
-    ///
-    /// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-tags
-    #[tracing::instrument(skip_all, fields(otel.name = name))]
-    async fn list_tags(&mut self, name: &str) -> anyhow::Result<BTreeSet<String>> {
-        let url = build_url!(&self, "/v2/{}/tags/list", name);
-        let request = self.transport.get(url);
-        let response = self.transport.send(request).await?;
-        match response.status() {
-            StatusCode::OK => {}
-            status => return Err(PyOciError::from((status, response.text().await?)).into()),
-        };
-        let mut link_header = match response.headers().get("link") {
-            Some(link) => Some(Link::try_from(link)?),
-            None => None,
-        };
-        let mut tags: BTreeSet<String> = response
-            .json::<TagList>()
-            .await?
-            .tags()
-            .iter()
-            .map(|f| f.to_string())
-            .collect();
-        while let Some(ref link) = link_header {
-            // Follow the link headers as long as a Link header is returned
-            let mut url = self.registry.clone();
-            url.set_path("");
-            let url = url.join(&link.0)?;
-            let request = self.transport.get(url);
-            let response = self.transport.send(request).await?;
-            match response.status() {
-                StatusCode::OK => {}
-                status => return Err(PyOciError::from((status, response.text().await?)).into()),
-            };
-            link_header = match response.headers().get("link") {
-                Some(link) => Some(Link::try_from(link)?),
-                None => None,
-            };
-            let tag_list = response.json::<TagList>().await?;
-            tags.extend(tag_list.tags().iter().map(|f| f.to_string()));
-        }
-
-        Ok(tags)
-    }
-
-    /// Push a manifest to the registry
-    ///
-    /// ImageIndex will be pushed with a version tag if version is set
-    /// ImageManifest will always be pushed with a digest reference
-    #[tracing::instrument(skip_all, fields(otel.name = name, otel.version = version))]
-    async fn push_manifest(
-        &mut self,
-        name: &str,
-        manifest: Manifest,
-        version: Option<&str>,
-    ) -> Result<()> {
-        let (url, data, content_type) = match manifest {
-            Manifest::Index(index) => {
-                let version = version.context("`version` required for pushing an ImageIndex")?;
-                let url = build_url!(&self, "v2/{}/manifests/{}", name, version);
-                let data = serde_json::to_string(&index)?;
-                (url, data, "application/vnd.oci.image.index.v1+json")
-            }
-            Manifest::Manifest(manifest) => {
-                let data = serde_json::to_string(&manifest)?;
-                let data_digest = digest(&data);
-                let url = build_url!(&self, "/v2/{}/manifests/{}", name, data_digest.as_ref());
-                (url, data, "application/vnd.oci.image.manifest.v1+json")
-            }
-        };
-
-        let request = self
-            .transport
-            .put(url)
-            .header("Content-Type", content_type)
-            .body(data);
-        let response = self.transport.send(request).await?;
-        match response.status() {
-            StatusCode::CREATED => {}
-            status => return Err(PyOciError::from((status, response.text().await?)).into()),
-        };
-        Ok(())
-    }
-
-    /// Pull a manifest from the registry
-    ///
-    /// If the manifest does not exist, Ok<None> is returned
-    /// If any other error happens, an Err is returned
-    #[tracing::instrument(skip_all, fields(otel.name = name, otel.reference = reference))]
-    async fn pull_manifest(&mut self, name: &str, reference: &str) -> Result<Option<Manifest>> {
-        let url = build_url!(&self, "/v2/{}/manifests/{}", name, reference);
-        let request = self.transport.get(url).header(
-            "Accept",
-            "application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json",
-        );
-        let response = self.transport.send(request).await?;
-        match response.status() {
-            StatusCode::NOT_FOUND => return Ok(None),
-            StatusCode::OK => {}
-            status => return Err(PyOciError::from((status, response.text().await?)).into()),
-        };
-
-        match response.headers().get("Content-Type") {
-            Some(value) if value == "application/vnd.oci.image.index.v1+json" => {
-                Ok(Some(Manifest::Index(Box::new(
-                    response
-                        .json::<ImageIndex>()
-                        .await
-                        .expect("valid Index json"),
-                ))))
-            }
-            Some(value) if value == "application/vnd.oci.image.manifest.v1+json" => {
-                Ok(Some(Manifest::Manifest(Box::new(
-                    response
-                        .json::<ImageManifest>()
-                        .await
-                        .expect("valid Manifest json"),
-                ))))
-            }
-            Some(content_type) => bail!("Unknown Content-Type: {}", content_type.to_str().unwrap()),
-            None => bail!("Missing Content-Type header"),
-        }
-    }
-
-    /// Delete a tag or manifest
-    ///
-    /// reference: tag or digest of the manifest to delete
-    /// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#content-management
-    #[tracing::instrument(skip_all, fields(otel.name = name, otel.reference = reference))]
-    async fn delete_manifest(&mut self, name: &str, reference: &str) -> Result<()> {
-        let url = build_url!(&self, "/v2/{}/manifests/{}", name, reference);
-        let request = self.transport.delete(url);
-        let response = self.transport.send(request).await?;
-        match response.status() {
-            StatusCode::ACCEPTED => Ok(()),
-            status => Err(PyOciError::from((status, response.text().await?)).into()),
-        }
-    }
-}
-
 /// static EmptyConfig Descriptor
 fn empty_config() -> Blob {
     Blob::new("{}".into(), "application/vnd.oci.empty.v1+json")
 }
 
-struct Link(String);
-
-impl TryFrom<&HeaderValue> for Link {
-    type Error = PyOciError;
-
-    fn try_from(value: &HeaderValue) -> std::result::Result<Self, Self::Error> {
-        let value = match value.to_str() {
-            Ok(value) => value,
-            _ => {
-                return Err(PyOciError::from((
-                    StatusCode::BAD_GATEWAY,
-                    "OCI registry provided invalid Link header",
-                )))
-            }
-        };
-        let parts = value.split(';').collect::<Vec<_>>();
-        tracing::debug!("{parts:?}");
-        let target = match parts.first().map(|f| f.trim()) {
-            Some(target) if target.starts_with('<') && target.ends_with('>') => {
-                target.strip_prefix('<').unwrap().strip_suffix('>').unwrap()
-            }
-            _ => {
-                return Err(PyOciError::from((
-                    StatusCode::BAD_GATEWAY,
-                    "OCI registry provided an invalid Link target",
-                )))
-            }
-        };
-
-        // Check the Link contains the correct "rel"
-        let mut valid_rel = false;
-        for param in &parts[1..] {
-            match param.split_once('=') {
-                Some((key, value)) if key.trim() == "rel" && value.trim() == "\"next\"" => {
-                    valid_rel = true
-                }
-                _ => {}
-            }
-        }
-        if !valid_rel {
-            return Err(PyOciError::from((
-                StatusCode::BAD_GATEWAY,
-                "OCI registry provide invalid Link rel",
-            )));
-        }
-        Ok(Link(target.to_string()))
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use oci_spec::image::ImageManifest;
     use pretty_assertions::assert_eq;
     use serde_json::from_str;
 
     use super::*;
-
-    #[test]
-    fn test_build_url() -> Result<()> {
-        let client = PyOci {
-            registry: Url::parse("https://example.com").expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
-        };
-        let url = build_url!(&client, "/foo/{}/", "latest");
-        assert_eq!(url.as_str(), "https://example.com/foo/latest/");
-        Ok(())
-    }
-
-    #[test]
-    fn test_build_url_absolute() -> Result<()> {
-        let client = PyOci {
-            registry: Url::parse("https://example.com").expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
-        };
-        let url = build_url!(&client, "{}/foo?bar=baz&qaz=sha:123", "http://pyoci.nl");
-        assert_eq!(url.as_str(), "http://pyoci.nl/foo?bar=baz&qaz=sha:123");
-        Ok(())
-    }
-
-    #[test]
-    fn test_build_url_double_period() {
-        let client = PyOci {
-            registry: Url::parse("https://example.com").expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
-        };
-        let x = || -> Result<Url> { Ok(build_url!(&client, "/foo/{}/", "..")) }();
-        assert!(x.is_err());
-    }
-
-    /// Test if a relative Location header is properly handled
-    #[tokio::test]
-    async fn test_push_blob_location_relative() {
-        let mut server = mockito::Server::new_async().await;
-        let url = server.url();
-
-        let mut mocks = vec![];
-        // Mock the server, in order of expected requests
-
-        // HEAD request to check if blob exists
-        mocks.push(
-            server
-                .mock(
-                    "HEAD",
-                    "/v2/mockserver/foobar/blobs/sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-                )
-                .with_status(404)
-                .create_async()
-                .await,
-        );
-        // POST request initiating blob upload
-        mocks.push(
-            server
-                .mock("POST", "/v2/mockserver/foobar/blobs/uploads/")
-                .with_status(202) // ACCEPTED
-                .with_header(
-                    "Location",
-                    "/v2/mockserver/foobar/blobs/uploads/1?_state=uploading",
-                )
-                .create_async()
-                .await,
-        );
-        // PUT request to upload blob
-        mocks.push(
-            server
-                .mock(
-                    "PUT",
-                    "/v2/mockserver/foobar/blobs/uploads/1?_state=uploading&digest=sha256%3A2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-                )
-                .with_status(201) // CREATED
-                .create_async()
-                .await,
-        );
-
-        let mut client = PyOci {
-            registry: Url::parse(&url).expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
-        };
-        let blob = Blob::new("hello".into(), "application/octet-stream");
-        let _ = client.push_blob("mockserver/foobar", blob).await;
-
-        for mock in mocks {
-            mock.assert_async().await;
-        }
-    }
-    /// Test if an absolute Location header is properly handled
-    #[tokio::test]
-    async fn test_push_blob_location_absolute() {
-        let mut server = mockito::Server::new_async().await;
-        let url = server.url();
-
-        let mut mocks = vec![];
-        // Mock the server, in order of expected requests
-
-        // HEAD request to check if blob exists
-        mocks.push(
-            server
-                .mock(
-                    "HEAD",
-                    "/v2/mockserver/foobar/blobs/sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-                )
-                .with_status(404)
-                .create_async()
-                .await,
-        );
-        // POST request initiating blob upload
-        mocks.push(
-            server
-                .mock("POST", "/v2/mockserver/foobar/blobs/uploads/")
-                .with_status(202) // ACCEPTED
-                .with_header(
-                    "Location",
-                    &format!("{url}/v2/mockserver/foobar/blobs/uploads/1?_state=uploading"),
-                )
-                .create_async()
-                .await,
-        );
-        // PUT request to upload blob
-        mocks.push(
-            server
-                .mock(
-                    "PUT",
-                    "/v2/mockserver/foobar/blobs/uploads/1?_state=uploading&digest=sha256%3A2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-                )
-                .with_status(201) // CREATED
-                .create_async()
-                .await,
-        );
-
-        let mut client = PyOci {
-            registry: Url::parse(&url).expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
-        };
-        let blob = Blob::new("hello".into(), "application/octet-stream");
-        let _ = client.push_blob("mockserver/foobar", blob).await;
-
-        for mock in mocks {
-            mock.assert_async().await;
-        }
-    }
 
     #[test]
     // Check if the digest is returned when no expected digest is provided
@@ -1064,125 +476,6 @@ mod tests {
             .downcast::<PyOciError>()
             .expect("Error should be PyOciError");
         assert_eq!(err.status, StatusCode::BAD_REQUEST);
-    }
-
-    #[tokio::test]
-    async fn list_tags() {
-        let mut server = mockito::Server::new_async().await;
-        let url = server.url();
-
-        let tags = r#"{
-          "name": "mockserver/bar",
-          "tags": [
-            "1",
-            "2",
-            "3"
-          ]
-        }"#;
-        server
-            .mock("GET", "/v2/mockserver/bar/tags/list")
-            .with_status(200)
-            .with_body(tags)
-            .create_async()
-            .await;
-
-        let mut pyoci = PyOci {
-            registry: Url::parse(&url).expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
-        };
-
-        let result = pyoci
-            .list_tags("mockserver/bar")
-            .await
-            .expect("Valid response");
-
-        assert_eq!(
-            result,
-            BTreeSet::from(["1".to_string(), "2".to_string(), "3".to_string()])
-        );
-    }
-
-    #[tokio::test]
-    async fn list_tags_link_header() {
-        let mut server = mockito::Server::new_async().await;
-        let url = server.url();
-
-        server
-            .mock("GET", "/v2/mockserver/bar/tags/list")
-            .with_header(
-                "Link",
-                "</v2/mockserver/bar/tags/list?n=3&last=3>; rel=\"next\"",
-            )
-            .with_status(200)
-            .with_body(
-                r#"{
-                  "name": "mockserver/bar",
-                  "tags": [
-                    "1",
-                    "2",
-                    "3"
-                  ]
-                }"#,
-            )
-            .create_async()
-            .await;
-
-        server
-            .mock("GET", "/v2/mockserver/bar/tags/list?n=3&last=3")
-            .with_header(
-                "Link",
-                "</v2/mockserver/bar/tags/list?n=3&last=6>; rel=\"next\"",
-            )
-            .with_status(200)
-            .with_body(
-                r#"{
-                  "name": "mockserver/bar",
-                  "tags": [
-                    "4",
-                    "5",
-                    "6"
-                  ]
-                }"#,
-            )
-            .create_async()
-            .await;
-
-        server
-            .mock("GET", "/v2/mockserver/bar/tags/list?n=3&last=6")
-            .with_status(200)
-            .with_body(
-                r#"{
-                  "name": "mockserver/bar",
-                  "tags": [
-                    "7"
-                  ]
-                }"#,
-            )
-            .create_async()
-            .await;
-
-        let mut pyoci = PyOci {
-            registry: Url::parse(&url).expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
-        };
-
-        let result = pyoci
-            .list_tags("mockserver/bar")
-            .await
-            .expect("Valid response");
-
-        assert_eq!(
-            result,
-            BTreeSet::from([
-                "1".to_string(),
-                "2".to_string(),
-                "3".to_string(),
-                "4".to_string(),
-                "5".to_string(),
-                "6".to_string(),
-                "7".to_string(),
-            ])
-        );
     }
 
     #[tokio::test]
@@ -1219,8 +512,7 @@ mod tests {
             .await;
 
         let pyoci = PyOci {
-            registry: Url::parse(&url).expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
+            oci: Oci::new(Url::parse(&url).expect("valid url"), None).unwrap(),
         };
 
         let package = Package::new("ghcr.io", "mockserver", "bar");
@@ -1271,8 +563,7 @@ mod tests {
             .await;
 
         let pyoci = PyOci {
-            registry: Url::parse(&url).expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
+            oci: Oci::new(Url::parse(&url).expect("valid url"), None).unwrap(),
         };
 
         let package = Package::new("ghcr.io", "mockserver", "bar");
@@ -1291,11 +582,6 @@ mod tests {
 
     #[test]
     fn image_manifest() {
-        let pyoci = PyOci {
-            registry: Url::parse("https://pyoci.com").expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
-        };
-
         let package =
             Package::from_filename("ghcr.io", "mockserver", "bar-1.tar.gz").expect("Valid Package");
         let layer = Blob::new(vec![b'q', b'w', b'e'], "test-artifact");
@@ -1304,7 +590,7 @@ mod tests {
             "test-annotation-value".to_string(),
         )]);
 
-        let result = pyoci.image_manifest(&package, &layer, annotations.clone());
+        let result = super::image_manifest(&package, &layer, annotations.clone());
         assert_eq!(
             result.manifest,
             from_str::<ImageManifest>(r#"{
@@ -1344,8 +630,7 @@ mod tests {
             .await;
 
         let mut pyoci = PyOci {
-            registry: Url::parse(&url).expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
+            oci: Oci::new(Url::parse(&url).expect("valid url"), None).unwrap(),
         };
 
         // Setup the objects we're publishing
@@ -1355,8 +640,8 @@ mod tests {
             .schema_version(SCHEMA_VERSION)
             .media_type("application/vnd.oci.image.manifest.v1+json")
             .artifact_type(ARTIFACT_TYPE)
-            .config(empty_config().descriptor)
-            .layers(vec![layer.descriptor])
+            .config(empty_config().descriptor().to_owned())
+            .layers(vec![layer.descriptor().to_owned()])
             .build()
             .expect("valid ImageManifest");
         let manifest = PlatformManifest::new(manifest, &package);
@@ -1442,8 +727,7 @@ mod tests {
             .await;
 
         let mut pyoci = PyOci {
-            registry: Url::parse(&url).expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
+            oci: Oci::new(Url::parse(&url).expect("valid url"), None).unwrap(),
         };
 
         // Setup the objects we're publishing
@@ -1453,8 +737,8 @@ mod tests {
             .schema_version(SCHEMA_VERSION)
             .media_type("application/vnd.oci.image.manifest.v1+json")
             .artifact_type(ARTIFACT_TYPE)
-            .config(empty_config().descriptor)
-            .layers(vec![layer.descriptor])
+            .config(empty_config().descriptor().clone())
+            .layers(vec![layer.descriptor().clone()])
             .build()
             .expect("valid ImageManifest");
         let manifest = PlatformManifest::new(manifest, &package);
@@ -1553,8 +837,7 @@ mod tests {
             .await;
 
         let mut pyoci = PyOci {
-            registry: Url::parse(&url).expect("valid url"),
-            transport: HttpTransport::new(None).unwrap(),
+            oci: Oci::new(Url::parse(&url).expect("valid url"), None).unwrap(),
         };
 
         // Setup the objects we're publishing
@@ -1564,8 +847,8 @@ mod tests {
             .schema_version(SCHEMA_VERSION)
             .media_type("application/vnd.oci.image.manifest.v1+json")
             .artifact_type(ARTIFACT_TYPE)
-            .config(empty_config().descriptor)
-            .layers(vec![layer.descriptor])
+            .config(empty_config().descriptor().clone())
+            .layers(vec![layer.descriptor().clone()])
             .build()
             .expect("valid ImageManifest");
         let manifest = PlatformManifest::new(manifest, &package);
@@ -1582,14 +865,5 @@ mod tests {
             result.message,
             "Platform '.tar.gz' already exists for version '1'"
         );
-    }
-
-    #[test]
-    fn link() {
-        let link = Link::try_from(&HeaderValue::from_static("</v2/allexveldman/hello_world/tags/list?last=0.0.1-example.1.poetry.2824051&n=5>; rel=\"next\"")).unwrap();
-        assert_eq!(
-            link.0,
-            "/v2/allexveldman/hello_world/tags/list?last=0.0.1-example.1.poetry.2824051&n=5"
-        )
     }
 }

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, bail, Context as _, Result};
 use futures::{ready, FutureExt};
 use http::{HeaderValue, StatusCode};
 use pin_project::pin_project;
+use serde::Deserialize;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
@@ -9,7 +10,14 @@ use std::task::{Context, Poll};
 use tower::{Layer, Service};
 use url::Url;
 
-use crate::pyoci::{AuthResponse, PyOciError};
+use crate::error::PyOciError;
+
+/// Response deserializer for the authentication request
+#[derive(Deserialize)]
+pub struct AuthResponse {
+    #[serde(alias = "access_token")]
+    pub token: String,
+}
 
 /// Authentication layer for the OCI registry
 /// This layer will handle [token authentication](https://distribution.github.io/distribution/spec/auth/token/)

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -11,39 +11,6 @@ use crate::service::AuthLayer;
 use crate::service::RequestLogLayer;
 use crate::USER_AGENT;
 
-pub trait Transport {
-    /// Send a request
-    ///
-    /// When authentication is required, this method will automatically authenticate
-    /// using the provided Basic auth string and caches the Bearer token for future requests within
-    /// this session.
-    async fn send(&mut self, request: reqwest::RequestBuilder) -> Result<reqwest::Response>;
-
-    /// Return the underlying client
-    fn client(&self) -> &reqwest::Client;
-
-    /// Create a new GET request
-    fn get(&self, url: url::Url) -> reqwest::RequestBuilder {
-        self.client().get(url)
-    }
-    /// Create a new POST request
-    fn post(&self, url: url::Url) -> reqwest::RequestBuilder {
-        self.client().post(url)
-    }
-    /// Create a new PUT request
-    fn put(&self, url: url::Url) -> reqwest::RequestBuilder {
-        self.client().put(url)
-    }
-    /// Create a new HEAD request
-    fn head(&self, url: url::Url) -> reqwest::RequestBuilder {
-        self.client().head(url)
-    }
-    /// Create a new DELETE request
-    fn delete(&self, url: url::Url) -> reqwest::RequestBuilder {
-        self.client().delete(url)
-    }
-}
-
 /// HTTP Transport
 ///
 /// This struct is responsible for sending HTTP requests to the upstream OCI registry.
@@ -93,15 +60,13 @@ impl HttpTransport {
             auth_layer: AuthLayer::new(auth)?,
         })
     }
-}
 
-impl Transport for HttpTransport {
     /// Send a request
     ///
     /// When authentication is required, this method will automatically authenticate
     /// using the provided Basic auth string and caches the Bearer token for future requests within
     /// this session.
-    async fn send(&mut self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
+    pub async fn send(&mut self, request: reqwest::RequestBuilder) -> Result<reqwest::Response> {
         let request = request.build()?;
 
         let mut service = ServiceBuilder::new()
@@ -114,8 +79,25 @@ impl Transport for HttpTransport {
         Ok(response)
     }
 
-    fn client(&self) -> &reqwest::Client {
-        &self.client
+    /// Create a new GET request
+    pub fn get(&self, url: url::Url) -> reqwest::RequestBuilder {
+        self.client.get(url)
+    }
+    /// Create a new POST request
+    pub fn post(&self, url: url::Url) -> reqwest::RequestBuilder {
+        self.client.post(url)
+    }
+    /// Create a new PUT request
+    pub fn put(&self, url: url::Url) -> reqwest::RequestBuilder {
+        self.client.put(url)
+    }
+    /// Create a new HEAD request
+    pub fn head(&self, url: url::Url) -> reqwest::RequestBuilder {
+        self.client.head(url)
+    }
+    /// Create a new DELETE request
+    pub fn delete(&self, url: url::Url) -> reqwest::RequestBuilder {
+        self.client.delete(url)
     }
 }
 


### PR DESCRIPTION
The layer implementing the OCI specification was mixed with the PyOCI specifics.

Now the implementation is split into 3 parts:
- HttpTransport: Sends (HTTP) requests to the upstream registry
- Oci: Implements the OCI specification
- PyOci: Implements the translation between Python packages and the OCI registry