### PR TITLE
feat(release): Allow building for multiple architectures

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -72,11 +72,11 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           no-cache: ${{ github.ref_type == 'tag' }}
-          load: false
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ env.REGISTRY_IMAGE }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          outputs: |
+            type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -91,6 +91,14 @@ jobs:
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
+
+      # Smoke-test the image
+      - uses: extractions/setup-just@v2
+      - uses: snok/install-poetry@v1
+      - uses: astral-sh/setup-uv@v5
+      - run: just test-smoke
+      - run: docker compose logs pyoci
+        working-directory: ./docker
 
   merge:
     runs-on: ubuntu-latest
@@ -142,20 +150,6 @@ jobs:
         if: github.ref_type == 'tag'
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
-
-  smoke-test:
-    runs-on: ubuntu-latest
-    name: Smoke Test
-    timeout-minutes: 15
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
-      - uses: snok/install-poetry@v1
-      - uses: astral-sh/setup-uv@v5
-      - run: just test-smoke
-      - run: docker compose logs pyoci
-        working-directory: ./docker
 
   deploy:
     name: Deploy

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     outputs:
       version: ${{ steps.meta.outputs.version }}
@@ -63,14 +63,19 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           no-cache: ${{ github.ref_type == 'tag' }}
-          load: true
+          load: false
           push: ${{ github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: 'linux/amd64,linux/arm64'
 
-      # Smoke-test the image
-      # The smoke test contains a build of the image but because the previous
-      # step defines `load: true` the entire build will be from cache.
+  smoke-test:
+    runs-on: ubuntu-latest
+    name: Smoke Test
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
       - uses: snok/install-poetry@v1
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,23 +19,110 @@ permissions:
   contents: read
   packages: write
 
+env:
+  REGISTRY_IMAGE: ghcr.io/allexveldman/pyoci
+
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./
+          file: docker/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          no-cache: ${{ github.ref_type == 'tag' }}
+          load: false
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY_IMAGE }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
     runs-on: ubuntu-latest
-    name: Build
-    timeout-minutes: 30
+    needs:
+      - build
 
     outputs:
       version: ${{ steps.meta.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/metadata-action@v5
-        name: Docker meta
-        id: meta
+      - name: Download digests
+        uses: actions/download-artifact@v4
         with:
-          images: |
-            ghcr.io/allexveldman/pyoci
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=schedule
             type=ref,event=branch
@@ -45,29 +132,16 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create ${{ github.ref_type != 'tag' && '--dry-run' || '' }} $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
 
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: ./
-          file: docker/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          no-cache: ${{ github.ref_type == 'tag' }}
-          load: false
-          push: ${{ github.ref_type == 'tag' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: 'linux/amd64,linux/arm64'
+      - name: Inspect image
+        if: github.ref_type == 'tag'
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
 
   smoke-test:
     runs-on: ubuntu-latest
@@ -85,11 +159,11 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: [build]
+    needs: [merge]
     if: github.ref_type == 'tag'
     uses: ./.github/workflows/deploy.yaml
     with:
-      version: ${{ needs.build.outputs.version }}
+      version: ${{ needs.merge.outputs.version }}
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,11 @@ ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 FROM rust:1.81.0 AS builder
 
-RUN rustup target add x86_64-unknown-linux-musl
+COPY docker/target-platform.sh /target-platform.sh
+
+ARG TARGETPLATFORM
+
+RUN rustup target add $(/target-platform.sh)
 RUN apt update \
     && apt install --no-install-recommends -y \
     musl-tools \
@@ -19,12 +23,13 @@ WORKDIR /pyoci
 # Build the dependencies as a separate step so they get cached.
 COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && echo "fn main(){}" > src/main.rs
-RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN cargo build --release --target $(/target-platform.sh)
 
 # Copy the actual sources
 COPY src ./src/
 RUN touch -a -m ./src/main.rs
-RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN cargo build --release --target $(/target-platform.sh) && \
+    mv /pyoci/target/$(/target-platform.sh)/release/pyoci /pyoci/target/pyoci
 
 
 FROM scratch
@@ -38,7 +43,7 @@ EXPOSE $PORT
 WORKDIR /pyoci
 COPY LICENSE LICENCE
 COPY templates ./templates/
-COPY --from=builder /pyoci/target/x86_64-unknown-linux-musl/release/pyoci pyoci
+COPY --from=builder /pyoci/target/pyoci pyoci
 
 USER pyoci
 

--- a/docker/target-platform.sh
+++ b/docker/target-platform.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Convert the TARGETPLATFORM environment variable
+# To the rust build target
+case $TARGETPLATFORM in
+    'linux/amd64')
+        echo -n 'x86_64-unknown-linux-musl';
+    ;;
+    'linux/arm64')
+        echo -n 'aarch64-unknown-linux-musl';
+    ;;
+    *)
+        echo "Unsupported TARGETPLATFORM: '$TARGETPLATFORM'" >&2;
+        exit 1;
+    ;;
+
+esac


### PR DESCRIPTION
The dockerfile requires some platform-dependent parts to be able to build with muslc so we can provide a `FROM scratch` final image.

This PR adds `docker/target-platform.sh` to translate between buildkit's `$TARGETPLATFORM` value and the platform triplet we need for the rust build.

Currently the image is build for `linux/amd64` and `linux/arm64`.
To speed up the ARM build, it is run on an ARM runner using the method described [here](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners)

closes: #250, related: #169
supersedes: #258  