### PR TITLE
feat: Stream response for file download

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ oci-spec = { version = "0.8.2", default-features = false, features = ["image", "
 url = "2.5.7"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }
-reqwest = { version = "0.12.23", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12.23", default-features = false, features = ["json", "rustls-tls", "stream"] }
 base64 = "0.22.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"


### PR DESCRIPTION
Changes the response of the file download to a chunked stream. This has two benefits:
- the first byte is returned faster for large packages
- we no longer load the entire package into memory when creating the response

<details><summary>changelog override</summary>
BEGIN_COMMIT_OVERRIDE

feat: Stream response for file download (#312)

END_COMMIT_OVERRIDE

</details