### PR TITLE
fix(auth): 502 when authenticating with `registry-1.docker.io`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use axum::response::IntoResponse;
 use http::StatusCode;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PyOciError {
     pub status: StatusCode,
     pub message: String,


### PR DESCRIPTION
`registry-1.docker.io`'s authentication response contains both a `token` and an `access_token` which causes a 502 in pyoci.

According to the spec:
> For compatibility with OAuth 2.0, we will also accept token under the name access_token.
At least one of these fields must be specified, but both may also appear (for compatibility with older clients). When both are specified, they should be equivalent; if they differ the client's choice is undefined.

Now we accept both fields in the response and prioritize the `token` key.