### PR TITLE
fix: package name not consistent in list results

### DIFF
--- a/docs/examples/justfile
+++ b/docs/examples/justfile
@@ -94,7 +94,7 @@ curl-list-json username token repository="http://localhost:8080/ghcr.io/allexvel
 
 [group("curl")]
 curl-download version username token repository="http://localhost:8080/ghcr.io/allexveldman/": (_group "curl-download") && _endgroup
-    curl -vOJ --fail-with-body -u {{username}}:{{token}} {{repository}}hello_world/hello_world-{{version}}.tar.gz
+    curl -vOJ --fail-with-body -u {{username}}:{{token}} {{repository}}hello-world/hello_world-{{version}}.tar.gz
     rm hello_world-{{version}}.tar.gz
 
 [group("curl")]

--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -577,8 +577,8 @@ mod tests {
 
     #[test]
     fn image_manifest() {
-        let package =
-            Package::from_filename("ghcr.io", "mockserver", "bar-1.tar.gz").expect("Valid Package");
+        let package = Package::from_filename("ghcr.io", "mockserver", "bar", "bar-1.tar.gz")
+            .expect("Valid Package");
         let layer = Blob::new(vec![b'q', b'w', b'e'], "test-artifact");
         let annotations = HashMap::from([(
             "test-annotation-key".to_string(),
@@ -629,7 +629,8 @@ mod tests {
         };
 
         // Setup the objects we're publishing
-        let package = Package::from_filename("ghcr.io", "mockserver", "bar-1.tar.gz").unwrap();
+        let package =
+            Package::from_filename("ghcr.io", "mockserver", "bar", "bar-1.tar.gz").unwrap();
         let layer = Blob::new(vec![b'q', b'w', b'e'], "test-artifact");
         let manifest = ImageManifestBuilder::default()
             .schema_version(SCHEMA_VERSION)
@@ -726,7 +727,8 @@ mod tests {
         };
 
         // Setup the objects we're publishing
-        let package = Package::from_filename("ghcr.io", "mockserver", "bar-1.tar.gz").unwrap();
+        let package =
+            Package::from_filename("ghcr.io", "mockserver", "bar", "bar-1.tar.gz").unwrap();
         let layer = Blob::new(vec![b'q', b'w', b'e'], "test-artifact");
         let manifest = ImageManifestBuilder::default()
             .schema_version(SCHEMA_VERSION)
@@ -836,7 +838,8 @@ mod tests {
         };
 
         // Setup the objects we're publishing
-        let package = Package::from_filename("ghcr.io", "mockserver", "bar-1.tar.gz").unwrap();
+        let package =
+            Package::from_filename("ghcr.io", "mockserver", "bar", "bar-1.tar.gz").unwrap();
         let layer = Blob::new(vec![b'q', b'w', b'e'], "test-artifact");
         let manifest = ImageManifestBuilder::default()
             .schema_version(SCHEMA_VERSION)


### PR DESCRIPTION
When listing a package containing a `-`, an URL was returned where the package name contains `_` instead.
Now the package name correctly retains the name as provided in the request.

When uploading a package, the name is now extracted from the form fields instead of parsed out of the filename.
For backwards compatibility the package is still stored in the OCI registry using the name with `_`.

related: https://github.com/AllexVeldman/pyoci/issues/329#issuecomment-3631607126