### PR TITLE
feat(auth): Accept Bearer tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ PyOCI is expected to run behind a reverse proxy that handles TLS termination, or
 - `PYOCI_MAX_VERSIONS`: Limit how many versions (in reverse alphabetical order) to fetch filenames for when listing a package.
     By default PyOCI will only include the last `100` versions.
     To not limit the versions, set this value to `0`.
+- `PYOCI_BEARER_USERNAME`: If set, PyOCI will use the password provided for this user as the Bearer token
+    for requests to the upstream OCI registry, skipping the normal token authentication flow.
 - `OTLP_ENDPOINT`: If set, forward logs, traces, and metrics to this OTLP collector endpoint every 30s.
 - `OTLP_AUTH`: Full Authorization header value to use when sending OTLP requests.
 - `RUST_LOG`: Log filter, defaults to `info`.
@@ -108,6 +110,12 @@ Note that this prefix is only reflected in the OCI registry, the package itself 
 ## Authentication
 Pip's [Basic authentication](https://pip.pypa.io/en/stable/topics/authentication/#basic-http-authentication)
 is forwarded as-is to the target registry as part of the [token authentication](https://distribution.github.io/distribution/spec/auth/token/) flow.
+
+If `PYOCI_BEARER_USERNAME` is set, the token authentication flow is skipped for that username and the password is used as the Bearer token directly.
+This can be useful if you already have the token for the registry, for example in CI workflows.
+
+For example, `PYOCI_BEARER_USERNAME="__token__"` will allow you to
+`pip install --index-url="http://__token__:<auth token>@<pyoci-url>/<OCI-registry-url>/<namespace>/" <package-name>`
 
 ## Changing a package
 PyOCI will refuse to upload a package file if the package name, version and architecture already exist.

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,6 @@ use std::{
 
 use axum::{
     body::Body,
-    debug_handler,
     extract::{multipart::MultipartError, DefaultBodyLimit, Multipart, Path, Request, State},
     http::header,
     response::{Html, IntoResponse, Redirect, Response},
@@ -65,6 +64,8 @@ struct PyOciState<'a> {
     subpath: Option<String>,
     /// Maximum versions `PyOCI` will fetch when listing a package
     max_versions: usize,
+    /// User Basic password as Bearer token if the username matches this value
+    bearer_username: Option<String>,
     /// HTML Template registry
     templates: Handlebars<'a>,
 }
@@ -125,6 +126,7 @@ fn router(env: &Env) -> Router {
             subpath: env.path.clone(),
             max_versions: env.max_versions,
             templates: template_reg,
+            bearer_username: env.bearer_username.clone(),
         })
 }
 
@@ -201,6 +203,7 @@ async fn list_package(
     State(PyOciState {
         subpath,
         max_versions,
+        bearer_username,
         templates,
     }): State<PyOciState<'_>>,
     auth: Option<TypedHeader<AuthHeader>>,
@@ -208,7 +211,7 @@ async fn list_package(
 ) -> Result<Html<String>, AppError> {
     let package = Package::new(&registry, &namespace, &package_name);
 
-    let mut client = PyOci::new(package.registry()?, get_auth(auth));
+    let mut client = PyOci::new(package.registry()?, get_auth(auth, bearer_username)?);
     let files = client.list_package_files(&package, max_versions).await?;
 
     let data = ListPkgTemplateData { files, subpath };
@@ -249,15 +252,17 @@ struct Info {
 ///
 /// Allows listing all releases without the additional file information
 /// Specifically this is used by Renovate to determine the available releases
-#[debug_handler]
 #[tracing::instrument(skip_all)]
 async fn list_package_json(
+    State(PyOciState {
+        bearer_username, ..
+    }): State<PyOciState<'_>>,
     auth: Option<TypedHeader<AuthHeader>>,
     Path((registry, namespace, package_name)): Path<(String, String, String)>,
 ) -> Result<Json<ListJson>, AppError> {
     let package = Package::new(&registry, &namespace, &package_name);
 
-    let mut client = PyOci::new(package.registry()?, get_auth(auth));
+    let mut client = PyOci::new(package.registry()?, get_auth(auth, bearer_username)?);
     let versions = client.list_package_versions(&package).await?;
 
     let mut project_urls = HashMap::new();
@@ -284,15 +289,17 @@ async fn list_package_json(
 }
 
 /// Download package request handler
-#[debug_handler]
 #[tracing::instrument(skip_all)]
 async fn download_package(
+    State(PyOciState {
+        bearer_username, ..
+    }): State<PyOciState<'_>>,
     Path((registry, namespace, package_name, filename)): Path<(String, String, String, String)>,
     auth: Option<TypedHeader<AuthHeader>>,
 ) -> Result<impl IntoResponse, AppError> {
     let package = Package::from_filename(&registry, &namespace, &package_name, &filename)?;
 
-    let mut client = PyOci::new(package.registry()?, get_auth(auth));
+    let mut client = PyOci::new(package.registry()?, get_auth(auth, bearer_username)?);
     let data = client.download_package_file(&package).await?.bytes_stream();
 
     Ok((
@@ -308,15 +315,17 @@ async fn download_package(
 ///
 /// This endpoint does not exist as an official spec in the python ecosystem
 /// and the underlying OCI distribution spec is not supported by default for some registries
-#[debug_handler]
 #[tracing::instrument(skip_all)]
 async fn delete_package_version(
+    State(PyOciState {
+        bearer_username, ..
+    }): State<PyOciState<'_>>,
     Path((registry, namespace, name, version)): Path<(String, String, String, String)>,
     auth: Option<TypedHeader<AuthHeader>>,
 ) -> Result<String, AppError> {
     let package = Package::new(&registry, &namespace, &name).with_oci_file(&version, "");
 
-    let mut client = PyOci::new(package.registry()?, get_auth(auth));
+    let mut client = PyOci::new(package.registry()?, get_auth(auth, bearer_username)?);
     client.delete_package_version(&package).await?;
     Ok("Deleted".into())
 }
@@ -324,9 +333,11 @@ async fn delete_package_version(
 /// Publish package request handler
 ///
 /// ref: <https://docs.pypi.org/api/upload/>
-#[debug_handler]
 #[tracing::instrument(skip_all)]
 async fn publish_package(
+    State(PyOciState {
+        bearer_username, ..
+    }): State<PyOciState<'_>>,
     Path((registry, namespace)): Path<(String, String)>,
     auth: Option<TypedHeader<AuthHeader>>,
     multipart: Multipart,
@@ -339,7 +350,7 @@ async fn publish_package(
         &form_data.package_name,
         &form_data.filename,
     )?;
-    let mut client = PyOci::new(package.registry()?, get_auth(auth));
+    let mut client = PyOci::new(package.registry()?, get_auth(auth, bearer_username)?);
 
     client
         .publish_package_file(
@@ -353,13 +364,25 @@ async fn publish_package(
     Ok("Published".into())
 }
 
-/// Parse the Authentication header, if provided
-fn get_auth(auth: Option<TypedHeader<AuthHeader>>) -> Option<AuthHeader> {
-    if let Some(TypedHeader(auth)) = auth {
-        Some(auth)
+/// Parse the Authentication header, if provided.
+///
+/// If pyoci was started with `PYOCI_BEARER_USERNAME` it will be compared
+/// with the provided username, if there is a match the password is used as the
+/// Bearer token directly.
+fn get_auth(
+    auth: Option<TypedHeader<AuthHeader>>,
+    bearer_username: Option<String>,
+) -> Result<Option<AuthHeader>, PyOciError> {
+    if let Some(TypedHeader(mut auth)) = auth {
+        // An Authorization header is provided
+        if let Some(bearer_username) = bearer_username {
+            // PYOCI_BEARER_USERNAME is set
+            auth = auth.maybe_into_bearer(&bearer_username)?;
+        }
+        Ok(Some(auth))
     } else {
         tracing::warn!("No Authorization header provided");
-        None
+        Ok(None)
     }
 }
 
@@ -562,18 +585,38 @@ mod tests {
     #[test]
     fn test_get_auth() {
         // Basic
-        let auth = get_auth(Some(TypedHeader(AuthHeader::Basic(Authorization::basic(
-            "user", "pass",
-        )))));
+        let auth = get_auth(
+            Some(TypedHeader(AuthHeader::Basic(Authorization::basic(
+                "user", "pass",
+            )))),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             auth,
             Some(AuthHeader::Basic(Authorization::basic("user", "pass")))
         );
+        // Basic into Bearer
+        let auth = get_auth(
+            Some(TypedHeader(AuthHeader::Basic(Authorization::basic(
+                "__user__", "pass",
+            )))),
+            Some("__user__".to_string()),
+        )
+        .unwrap();
+        assert_eq!(
+            auth,
+            Some(AuthHeader::Bearer(Authorization::bearer("pass").unwrap()))
+        );
 
         // Bearer
-        let auth = get_auth(Some(TypedHeader(AuthHeader::Bearer(
-            Authorization::bearer("foobar").unwrap(),
-        ))));
+        let auth = get_auth(
+            Some(TypedHeader(AuthHeader::Bearer(
+                Authorization::bearer("foobar").unwrap(),
+            ))),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             auth,
             Some(AuthHeader::Bearer(Authorization::bearer("foobar").unwrap()))
@@ -582,7 +625,7 @@ mod tests {
 
     #[test]
     fn test_get_auth_none() {
-        let auth = get_auth(None);
+        let auth = get_auth(None, None).unwrap();
         assert_eq!(auth, None);
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,7 @@ use axum::{
 use axum_extra::TypedHeader;
 use bytes::Bytes;
 use handlebars::Handlebars;
-use headers::{authorization::Basic, Authorization, Host, UserAgent};
+use headers::{Host, UserAgent};
 use http::{header::CACHE_CONTROL, HeaderValue, StatusCode};
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use tower::Service;
@@ -25,6 +25,7 @@ use crate::{
     error::PyOciError,
     middleware::EncodeNamespace,
     package::{Package, WithFileName},
+    service::AuthHeader,
     Env, PyOci,
 };
 
@@ -202,7 +203,7 @@ async fn list_package(
         max_versions,
         templates,
     }): State<PyOciState<'_>>,
-    auth: Option<TypedHeader<Authorization<Basic>>>,
+    auth: Option<TypedHeader<AuthHeader>>,
     Path((registry, namespace, package_name)): Path<(String, String, String)>,
 ) -> Result<Html<String>, AppError> {
     let package = Package::new(&registry, &namespace, &package_name);
@@ -251,7 +252,7 @@ struct Info {
 #[debug_handler]
 #[tracing::instrument(skip_all)]
 async fn list_package_json(
-    auth: Option<TypedHeader<Authorization<Basic>>>,
+    auth: Option<TypedHeader<AuthHeader>>,
     Path((registry, namespace, package_name)): Path<(String, String, String)>,
 ) -> Result<Json<ListJson>, AppError> {
     let package = Package::new(&registry, &namespace, &package_name);
@@ -287,7 +288,7 @@ async fn list_package_json(
 #[tracing::instrument(skip_all)]
 async fn download_package(
     Path((registry, namespace, package_name, filename)): Path<(String, String, String, String)>,
-    auth: Option<TypedHeader<Authorization<Basic>>>,
+    auth: Option<TypedHeader<AuthHeader>>,
 ) -> Result<impl IntoResponse, AppError> {
     let package = Package::from_filename(&registry, &namespace, &package_name, &filename)?;
 
@@ -311,7 +312,7 @@ async fn download_package(
 #[tracing::instrument(skip_all)]
 async fn delete_package_version(
     Path((registry, namespace, name, version)): Path<(String, String, String, String)>,
-    auth: Option<TypedHeader<Authorization<Basic>>>,
+    auth: Option<TypedHeader<AuthHeader>>,
 ) -> Result<String, AppError> {
     let package = Package::new(&registry, &namespace, &name).with_oci_file(&version, "");
 
@@ -327,7 +328,7 @@ async fn delete_package_version(
 #[tracing::instrument(skip_all)]
 async fn publish_package(
     Path((registry, namespace)): Path<(String, String)>,
-    auth: Option<TypedHeader<Authorization<Basic>>>,
+    auth: Option<TypedHeader<AuthHeader>>,
     multipart: Multipart,
 ) -> Result<String, AppError> {
     let form_data = UploadForm::from_multipart(multipart).await?;
@@ -353,11 +354,13 @@ async fn publish_package(
 }
 
 /// Parse the Authentication header, if provided
-fn get_auth(auth: Option<TypedHeader<Authorization<Basic>>>) -> Option<Authorization<Basic>> {
-    if auth.is_none() {
+fn get_auth(auth: Option<TypedHeader<AuthHeader>>) -> Option<AuthHeader> {
+    if let Some(TypedHeader(auth)) = auth {
+        Some(auth)
+    } else {
         tracing::warn!("No Authorization header provided");
+        None
     }
-    auth.map(|h| (*h).clone())
 }
 
 trait MaybeEmpty {
@@ -543,6 +546,7 @@ mod tests {
         extract::{FromRequest, Request},
     };
     use bytes::Bytes;
+    use headers::Authorization;
     use http::HeaderValue;
     use indoc::formatdoc;
     use oci_spec::{
@@ -557,8 +561,23 @@ mod tests {
 
     #[test]
     fn test_get_auth() {
-        let auth = get_auth(Some(TypedHeader(Authorization::basic("user", "pass"))));
-        assert_eq!(auth, Some(Authorization::basic("user", "pass")));
+        // Basic
+        let auth = get_auth(Some(TypedHeader(AuthHeader::Basic(Authorization::basic(
+            "user", "pass",
+        )))));
+        assert_eq!(
+            auth,
+            Some(AuthHeader::Basic(Authorization::basic("user", "pass")))
+        );
+
+        // Bearer
+        let auth = get_auth(Some(TypedHeader(AuthHeader::Bearer(
+            Authorization::bearer("foobar").unwrap(),
+        ))));
+        assert_eq!(
+            auth,
+            Some(AuthHeader::Bearer(Authorization::bearer("foobar").unwrap()))
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,8 @@ struct Env {
     body_limit: usize,
     /// Maximum number of version `PyOCI` will fetch when listing a package
     max_versions: usize,
+    /// User Basic auth password as Bearer token if this username is used
+    bearer_username: Option<String>,
 }
 
 impl Env {
@@ -82,6 +84,7 @@ impl Env {
             replica_name: None,
             body_limit: 50_000_000,
             max_versions: 100,
+            bearer_username: None,
         }
     }
     fn new() -> Self {
@@ -92,15 +95,14 @@ impl Env {
                 .expect("Failed to parse PORT"),
             rust_log: env::var("RUST_LOG").unwrap_or("info".to_string()),
             path: clean_subpath(env::var("PYOCI_PATH").ok()),
-            body_limit: env::var("PYOCI_MAX_BODY")
-                .map(|f| f.parse().expect("PYOCI_MAX_BODY is not a valid integer"))
-                .unwrap_or(50_000_000),
-            max_versions: env::var("PYOCI_MAX_VERSIONS")
-                .map(|f| {
-                    f.parse()
-                        .expect("PYOCI_MAX_VERSIONS is not a valid integer")
-                })
-                .unwrap_or(100),
+            body_limit: env::var("PYOCI_MAX_BODY").map_or(50_000_000, |f| {
+                f.parse().expect("PYOCI_MAX_BODY is not a valid integer")
+            }),
+            max_versions: env::var("PYOCI_MAX_VERSIONS").map_or(100, |f| {
+                f.parse()
+                    .expect("PYOCI_MAX_VERSIONS is not a valid integer")
+            }),
+            bearer_username: env::var("PYOCI_BEARER_USERNAME").ok(),
             otlp_endpoint: env::var("OTLP_ENDPOINT").ok(),
             otlp_auth: env::var("OTLP_AUTH").ok(),
             deployment_env: env::var("DEPLOYMENT_ENVIRONMENT").ok(),

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -5,7 +5,6 @@ use std::{
 
 use anyhow::{bail, Context, Result};
 use base16ct::lower::encode_string as hex_encode;
-use headers::{authorization::Basic, Authorization};
 use http::{HeaderValue, StatusCode};
 use oci_spec::{
     distribution::TagList,
@@ -21,6 +20,7 @@ use url::Url;
 use crate::{
     error::PyOciError,
     package::{Package, WithFileName},
+    service::AuthHeader,
     transport::HttpTransport,
 };
 
@@ -135,7 +135,7 @@ pub struct Oci {
 
 /// Low-level functionality for interacting with the OCI registry
 impl Oci {
-    pub fn new(registry: Url, auth: Option<Authorization<Basic>>) -> Oci {
+    pub fn new(registry: Url, auth: Option<AuthHeader>) -> Oci {
         Oci {
             registry,
             transport: HttpTransport::new(auth),

--- a/src/pyoci.rs
+++ b/src/pyoci.rs
@@ -1,8 +1,6 @@
 use anyhow::{bail, Error, Result};
 use futures::stream::FuturesOrdered;
 use futures::stream::StreamExt;
-use headers::authorization::Basic;
-use headers::Authorization;
 use http::StatusCode;
 use oci_spec::image::{
     ImageIndex, ImageIndexBuilder, ImageManifestBuilder, MediaType, SCHEMA_VERSION,
@@ -19,6 +17,7 @@ use crate::oci::Blob;
 use crate::oci::Manifest;
 use crate::oci::Oci;
 use crate::oci::PlatformManifest;
+use crate::service::AuthHeader;
 use crate::time::now_utc;
 
 use crate::package::{Package, WithFileName, WithoutFileName};
@@ -32,7 +31,7 @@ pub struct PyOci {
 
 impl PyOci {
     /// Create a new Client
-    pub fn new(registry: Url, auth: Option<Authorization<Basic>>) -> PyOci {
+    pub fn new(registry: Url, auth: Option<AuthHeader>) -> PyOci {
         PyOci {
             oci: Oci::new(registry, auth),
         }

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -22,6 +22,30 @@ pub enum AuthHeader {
     Bearer(Authorization<Bearer>),
 }
 
+impl AuthHeader {
+    /// Convert an [`AuthHeader::Basic`] into a [`AuthHeader::Bearer`] if the username matches.
+    ///
+    /// The (decoded) password will be used as the Bearer token.
+    ///
+    /// Returns  `self` unchanged if it is not Basic or the username does not match.
+    /// Returns Err if the token is not a valid Bearer token.
+    pub fn maybe_into_bearer(self, username: &str) -> Result<Self, PyOciError> {
+        match self {
+            AuthHeader::Basic(auth) if auth.username() == username => {
+                tracing::info!(
+                    "Username matched PYOCI_BEARER_USERNAME, skipping password authentication"
+                );
+                Ok(Self::Bearer(
+                    Authorization::bearer(auth.password())
+                        .map_err(|err| (StatusCode::BAD_REQUEST, err.to_string()))?,
+                ))
+            }
+            _ => Ok(self),
+        }
+    }
+}
+
+/// Allow [`AuthHeader`] to be used as a [`TypedHeader`]
 impl Header for AuthHeader {
     fn name() -> &'static http::HeaderName {
         &::http::header::AUTHORIZATION
@@ -170,7 +194,7 @@ where
 
     fn call(&mut self, mut request: reqwest::Request) -> Self::Future {
         if let Some(bearer) = self.bearer.read().expect("Failed to get read lock").clone() {
-            // If we have a bearer token, add it to the request
+            // We have a bearer token, add it to the request
             request.headers_mut().typed_insert(bearer);
         }
         AuthFuture::new(
@@ -271,6 +295,7 @@ where
                         return Poll::Ready(Ok(response));
                     }
 
+                    // Extract the WWW-Authenticate header indicating where and how to authenticate
                     let www_auth = match response.headers().get("WWW-Authenticate") {
                         None => {
                             return Poll::Ready(Err(PyOciError::from((
@@ -295,8 +320,10 @@ where
                     // Use the raw underlying service, not AuthService, so that a 401
                     // from the token endpoint is not itself subject to re-authentication.
                     let srv = this.auth.service.clone();
+                    // Set the current Future state to Authenticating while `authenticate`
+                    // is awaited.
                     this.state.set(AuthState::Authenticating {
-                        // No idea how to type this Future, lets just Pin<Box> it
+                        // NOTE: No idea how to type this Future, lets just Pin<Box> it
                         future: authenticate(basic_token, www_auth, srv).boxed(),
                     });
                 }
@@ -309,7 +336,9 @@ where
                             .request
                             .take()
                             .ok_or_else(|| anyhow!("Tried to retry twice after authentication"))?;
+                        // Insert the new bearer token into the original request
                         request.headers_mut().typed_insert(bearer_token.clone());
+                        // Store the bearer token for later use
                         this.auth
                             .bearer
                             .write()
@@ -468,6 +497,25 @@ mod tests {
     use reqwest::{Body, Client};
     use tower::ServiceBuilder;
     use url::Url;
+
+    // Check if we can convert a Basic auth header into a Bearer auth header
+    #[test]
+    fn auth_header_into_bearer() {
+        let header: AuthHeader = Authorization::basic("__pyoci__", "somepassword").into();
+        // See that nothing happens if the username does not match
+        let header = header.maybe_into_bearer("foo").unwrap();
+        assert!(matches!(header, AuthHeader::Basic(_)));
+        // See if we can de the conversion
+        let header = header.maybe_into_bearer("__pyoci__").unwrap();
+        assert!(
+            matches!(header, AuthHeader::Bearer(Authorization(ref auth)) if auth.token() == "somepassword")
+        );
+        // Check that nothing happens when we already have a bearer
+        let header = header.maybe_into_bearer("__pyoci__").unwrap();
+        assert!(
+            matches!(header, AuthHeader::Bearer(Authorization(auth)) if auth.token() == "somepassword")
+        );
+    }
 
     // Check if the `token` key is used if present
     #[test]

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -1,19 +1,63 @@
 use anyhow::{anyhow, bail, Context as _, Result};
-use futures::{ready, FutureExt};
+use futures::FutureExt;
 use headers::authorization::{Basic, Bearer};
-use headers::Authorization;
 use headers::HeaderMapExt;
+use headers::{Authorization, Header};
 use http::{HeaderValue, StatusCode};
 use pin_project::pin_project;
 use serde::Deserialize;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use tower::{Layer, Service};
 use url::Url;
 
 use crate::error::PyOciError;
+
+/// Authorization header that can be either Basic or Bearer
+#[derive(Debug, PartialEq)]
+pub enum AuthHeader {
+    Basic(Authorization<Basic>),
+    Bearer(Authorization<Bearer>),
+}
+
+impl Header for AuthHeader {
+    fn name() -> &'static http::HeaderName {
+        &::http::header::AUTHORIZATION
+    }
+
+    fn decode<'i, I>(values: &mut I) -> std::result::Result<Self, headers::Error>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        if let Ok(auth) = Authorization::<Basic>::decode(values) {
+            Ok(Self::Basic(auth))
+        } else {
+            Authorization::<Bearer>::decode(values).map(Self::Bearer)
+        }
+    }
+
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+        match self {
+            Self::Basic(auth) => auth.encode(values),
+            Self::Bearer(auth) => auth.encode(values),
+        }
+    }
+}
+
+impl From<Authorization<Basic>> for AuthHeader {
+    fn from(value: Authorization<Basic>) -> Self {
+        Self::Basic(value)
+    }
+}
+
+impl From<Authorization<Bearer>> for AuthHeader {
+    fn from(value: Authorization<Bearer>) -> Self {
+        Self::Bearer(value)
+    }
+}
 
 /// Response deserializer for the authentication request
 /// ref: <https://distribution.github.io/distribution/spec/auth/token/>
@@ -54,10 +98,29 @@ pub struct AuthLayer {
 }
 
 impl AuthLayer {
-    pub fn new(basic_token: Option<Authorization<Basic>>) -> Self {
-        Self {
-            basic: basic_token,
-            bearer: Arc::new(RwLock::new(None)),
+    pub fn new(basic_token: Option<AuthHeader>) -> Self {
+        match basic_token {
+            None => Self::default(),
+            Some(auth) => Self::from(auth),
+        }
+    }
+}
+
+impl From<AuthHeader> for AuthLayer {
+    /// Create an [`AuthLayer`] from [`AuthHeader`].
+    ///
+    /// If we got a Basic token we'll try to exchange it for a Bearer token.
+    /// If we got a Bearer token we'll use it directly.
+    fn from(auth: AuthHeader) -> Self {
+        match auth {
+            AuthHeader::Basic(basic) => Self {
+                basic: Some(basic),
+                bearer: Arc::default(),
+            },
+            AuthHeader::Bearer(bearer) => Self {
+                basic: None,
+                bearer: Arc::new(RwLock::new(Some(bearer))),
+            },
         }
     }
 }
@@ -192,12 +255,21 @@ where
                     }
                     let basic_token = this.auth.basic.clone();
                     // If at this point we already have a bearer token, it did not have the correct
-                    // scope for the current request. Drop it so it won't be used again
-                    this.auth
+                    // scope for the current request. Drop it so it won't be used again.
+                    if this
+                        .auth
                         .bearer
                         .write()
                         .map_err(|_| anyhow!("Another thread panicked while writing bearer token"))?
-                        .take();
+                        .take()
+                        .is_some()
+                        && basic_token.is_none()
+                    {
+                        // If we don't also have a basic token it means we either got a
+                        // bearer token to begin with, or got a bearer token from an anonymous
+                        // exchange with the wrong scope. Either way there is nothing more to do.
+                        return Poll::Ready(Ok(response));
+                    }
 
                     let www_auth = match response.headers().get("WWW-Authenticate") {
                         None => {
@@ -489,7 +561,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some(Authorization::basic("user", "pass"))))
+            .layer(AuthLayer::new(Some(
+                Authorization::basic("user", "pass").into(),
+            )))
             .service(Client::default());
         let request = reqwest::Request::new(
             http::Method::GET,
@@ -542,7 +616,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some(Authorization::basic("user", "pass"))))
+            .layer(AuthLayer::new(Some(
+                Authorization::basic("user", "pass").into(),
+            )))
             .service(Client::default());
         let request = reqwest::Request::new(
             http::Method::GET,
@@ -633,7 +709,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some(Authorization::basic("user", "pass"))))
+            .layer(AuthLayer::new(Some(
+                Authorization::basic("user", "pass").into(),
+            )))
             .service(Client::default());
 
         // First request
@@ -679,7 +757,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some(Authorization::basic("user", "pass"))))
+            .layer(AuthLayer::new(Some(
+                Authorization::basic("user", "pass").into(),
+            )))
             .service(Client::default());
 
         // Construct a request that can't be cloned
@@ -798,6 +878,77 @@ mod tests {
         assert_eq!(response.text().await.unwrap(), "Unauthorized");
     }
 
+    // Test if the bearer token is used when provided on the original request
+    #[tokio::test]
+    async fn auth_service_bearer() {
+        let mut server = Server::new_async().await;
+        let url = server.url();
+        let mocks = vec![
+            server
+                .mock("GET", "/foobar")
+                .match_header("Authorization", "Bearer providedtoken")
+                .with_status(200)
+                .with_body("Hello, world!")
+                .create_async()
+                .await,
+        ];
+
+        let mut service = ServiceBuilder::new()
+            .layer(AuthLayer::new(Some(
+                Authorization::bearer("providedtoken").unwrap().into(),
+            )))
+            .service(Client::default());
+        let request = reqwest::Request::new(
+            http::Method::GET,
+            Url::parse(&format!("{url}/foobar")).unwrap(),
+        );
+
+        let response = service.call(request).await.unwrap();
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.text().await.unwrap(), "Hello, world!");
+    }
+
+    // Test if the original response is returned if the bearer token is not enough
+    #[tokio::test]
+    async fn auth_service_bearer_invalid() {
+        let mut server = Server::new_async().await;
+        let url = server.url();
+        let mocks = vec![
+            // Response to unauthenticated request
+            server
+                .mock("GET", "/foobar")
+                .match_header("Authorization", "Bearer providedtoken")
+                .with_status(401)
+                .with_header(
+                    "WWW-Authenticate",
+                    &format!("Bearer realm=\"{url}/token\",service=\"pyoci.fakeservice\""),
+                )
+                .with_body("Unauthorized")
+                .create_async()
+                .await,
+        ];
+
+        let mut service = ServiceBuilder::new()
+            .layer(AuthLayer::new(Some(
+                Authorization::bearer("providedtoken").unwrap().into(),
+            )))
+            .service(Client::default());
+        let request = reqwest::Request::new(
+            http::Method::GET,
+            Url::parse(&format!("{url}/foobar")).unwrap(),
+        );
+
+        let response = service.call(request).await.unwrap();
+        for mock in mocks {
+            mock.assert_async().await;
+        }
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.text().await.unwrap(), "Unauthorized");
+    }
     // Test if BAD_GATEWAY is returned on response of the upsteam server without a
     // WWW-Authenticate header.
     #[tokio::test]
@@ -814,7 +965,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some(Authorization::basic("user", "pass"))))
+            .layer(AuthLayer::new(Some(
+                Authorization::basic("user", "pass").into(),
+            )))
             .service(Client::default());
 
         let request = reqwest::Request::new(
@@ -858,7 +1011,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some(Authorization::basic("user", "pass"))))
+            .layer(AuthLayer::new(Some(
+                Authorization::basic("user", "pass").into(),
+            )))
             .service(Client::default());
 
         let request = reqwest::Request::new(
@@ -912,7 +1067,9 @@ mod tests {
         ];
 
         let mut service = ServiceBuilder::new()
-            .layer(AuthLayer::new(Some(Authorization::basic("user", "pass"))))
+            .layer(AuthLayer::new(Some(
+                Authorization::basic("user", "pass").into(),
+            )))
             .service(Client::default());
 
         let request = reqwest::Request::new(

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,5 +1,5 @@
 mod auth;
 mod log;
 
-pub use auth::{AuthLayer, AuthService};
+pub use auth::{AuthHeader, AuthLayer, AuthService};
 pub use log::{RequestLog, RequestLogLayer};

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
-use headers::authorization::Basic;
-use headers::Authorization;
 use std::future::poll_fn;
 use tower::{Service, ServiceBuilder};
 
+use crate::service::AuthHeader;
 use crate::service::AuthLayer;
 use crate::service::AuthService;
 use crate::service::RequestLog;
@@ -25,7 +24,7 @@ impl HttpTransport {
     ///
     /// auth: Basic auth string
     ///       Will be swapped for a Bearer token if needed
-    pub fn new(auth: Option<Authorization<Basic>>) -> Self {
+    pub fn new(auth: Option<AuthHeader>) -> Self {
         let client = reqwest::Client::builder()
             .user_agent(USER_AGENT)
             .build()
@@ -78,6 +77,7 @@ impl HttpTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use headers::Authorization;
     use http::StatusCode;
     use url::Url;
 
@@ -141,7 +141,7 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(Some(Authorization::basic("user", "pass")));
+        let mut transport = HttpTransport::new(Some(Authorization::basic("user", "pass").into()));
         let request = transport.get(Url::parse(&format!("{url}/foobar")).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -197,7 +197,7 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(Some(Authorization::basic("user", "pass")));
+        let mut transport = HttpTransport::new(Some(Authorization::basic("user", "pass").into()));
         // clone the transport to check if they share the bearer token state
         let mut transport2 = transport.clone();
 
@@ -326,7 +326,7 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(Some(Authorization::basic("user", "pass")));
+        let mut transport = HttpTransport::new(Some(Authorization::basic("user", "pass").into()));
         let request = transport.get(Url::parse(&format!("{url}/foobar")).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {
@@ -372,7 +372,7 @@ mod tests {
                 .await,
         ];
 
-        let mut transport = HttpTransport::new(Some(Authorization::basic("user", "pass")));
+        let mut transport = HttpTransport::new(Some(Authorization::basic("user", "pass").into()));
         let request = transport.get(Url::parse(&format!("{url}/foobar")).unwrap());
         let response = transport.send(request).await.unwrap();
         for mock in mocks {


### PR DESCRIPTION
Allow users to pass an `Authorization: Bearer <token>` header instead of `Basic`.

The bearer token will be used to authenticate directly to the oci registry instead of the regular basic auth token exchange.

It is also possible to define a username by setting `PYOCI_BEARER_USERNAME` that requests will match, if they match the provided password is used as the Bearer token.
This allows providing Bearer tokens directly while using python clients that only support Basic authentication.

closes #419 